### PR TITLE
Clarify naming of SFX_GET_EGG_* pointers

### DIFF
--- a/audio/sfx.asm
+++ b/audio/sfx.asm
@@ -1060,15 +1060,13 @@ Sfx_3RdPlace_Ch7:
 
 	togglesfx
 
-Sfx_GetEggFromDayCareLady:
-Sfx_GetEggFromDayCareMan:
-	musicheader 4, 5, Sfx_GetEggFromDayCareLady_Ch5
-	musicheader 1, 6, Sfx_GetEggFromDayCareLady_Ch6
-	musicheader 1, 7, Sfx_GetEggFromDayCareLady_Ch7
-	musicheader 1, 8, Sfx_GetEggFromDayCareLady_Ch8
+Sfx_GetEgg:
+	musicheader 4, 5, Sfx_GetEgg_Ch5
+	musicheader 1, 6, Sfx_GetEgg_Ch6
+	musicheader 1, 7, Sfx_GetEgg_Ch7
+	musicheader 1, 8, Sfx_GetEgg_Ch8
 
-Sfx_GetEggFromDayCareLady_Ch5:
-Sfx_GetEggFromDayCareMan_Ch5:
+Sfx_GetEgg_Ch5:
 	togglesfx
 	tempo 120
 	volume $77
@@ -1100,8 +1098,7 @@ Sfx_GetEggFromDayCareMan_Ch5:
 
 	togglesfx
 
-Sfx_GetEggFromDayCareLady_Ch6:
-Sfx_GetEggFromDayCareMan_Ch6:
+Sfx_GetEgg_Ch6:
 	togglesfx
 	vibrato $12, $34
 	dutycycle $3
@@ -1130,8 +1127,7 @@ Sfx_GetEggFromDayCareMan_Ch6:
 
 	togglesfx
 
-Sfx_GetEggFromDayCareLady_Ch7:
-Sfx_GetEggFromDayCareMan_Ch7:
+Sfx_GetEgg_Ch7:
 	togglesfx
 	notetype $8, $25
 	note __, 2
@@ -1150,8 +1146,7 @@ Sfx_GetEggFromDayCareMan_Ch7:
 
 	togglesfx
 
-Sfx_GetEggFromDayCareLady_Ch8:
-Sfx_GetEggFromDayCareMan_Ch8:
+Sfx_GetEgg_Ch8:
 	togglesfx
 	sfxtogglenoise $4
 	notetype $8

--- a/audio/sfx_pointers.asm
+++ b/audio/sfx_pointers.asm
@@ -149,8 +149,8 @@ SFX:
 	dba Sfx_Fanfare2
 	dba Sfx_RegisterPhoneNumber
 	dba Sfx_3RdPlace
-	dba Sfx_GetEggFromDayCareMan
-	dba Sfx_GetEggFromDayCareLady
+	dba Sfx_GetEgg
+	dba Sfx_GetEgg
 	dba Sfx_MoveDeleted
 	dba Sfx_2ndPlace
 	dba Sfx_1stPlace

--- a/constants/sfx_constants.asm
+++ b/constants/sfx_constants.asm
@@ -149,8 +149,8 @@
 	const SFX_FANFARE_2                   ; 92
 	const SFX_REGISTER_PHONE_NUMBER       ; 93
 	const SFX_3RD_PLACE                   ; 94
-	const SFX_GET_EGG_FROM_DAYCARE_MAN    ; 95
-	const SFX_GET_EGG_FROM_DAYCARE_LADY   ; 96
+	const SFX_GET_EGG_UNUSED              ; 95
+	const SFX_GET_EGG                     ; 96
 	const SFX_MOVE_DELETED                ; 97
 	const SFX_2ND_PLACE                   ; 98
 	const SFX_1ST_PLACE                   ; 99

--- a/engine/events/daycare.asm
+++ b/engine/events/daycare.asm
@@ -416,7 +416,7 @@ DayCareManOutside:
 	call DayCare_InitBreeding
 	ld hl, .GotEggText
 	call PrintText
-	ld de, SFX_GET_EGG_FROM_DAYCARE_LADY
+	ld de, SFX_GET_EGG
 	call PlaySFX
 	ld c, 120
 	call DelayFrames


### PR DESCRIPTION
In game, one receives eggs from the Aide and the Day-care Man, not the Day-care Lady. SFX 0x96 is used for both. Rename it to reflect it is not unique to the Day-care.

SFX 0x95 is an alias of the same sound and appears to be unused. Rename the pointer to clarify that.