### PR TITLE
Fix an uninitialized read bug in lzcomp

### DIFF
--- a/gfx/lz.mk
+++ b/gfx/lz.mk
@@ -44,8 +44,9 @@ gfx/tilesets/johto_modern.2bpp.lz: LZFLAGS = --compressor null --method 1 --alig
 gfx/tilesets/kanto.2bpp.lz: LZFLAGS = --compressor null --method 1 --align 1
 gfx/tilesets/mansion.2bpp.lz: LZFLAGS += --method 2 --align 4
 gfx/tilesets/mart.2bpp.lz: LZFLAGS += --method 2 --align 4
+gfx/tilesets/players_room.2bpp.lz: LZFLAGS += --method 4 --align 4
 gfx/tilesets/radio_tower.2bpp.lz: LZFLAGS += --method 2 --align 4
-gfx/tilesets/ruins_of_alph.2bpp.lz: LZFLAGS += --method 2 --align 4
+gfx/tilesets/ruins_of_alph.2bpp.lz: LZFLAGS += --method 6 --align 4
 gfx/tilesets/tower.2bpp.lz: LZFLAGS += --method 2 --align 4
 
 gfx/title/hooh_gold.2bpp.lz: LZFLAGS += --align 3

--- a/tools/lz/mpcomp.c
+++ b/tools/lz/mpcomp.c
@@ -101,7 +101,7 @@ struct command pick_copy_for_pass (const unsigned char * data, const unsigned ch
       current = buffer + refpos - (length - 3);
     else
       current = reference + refpos;
-    if (memcmp(data + position, current, 4)) continue;
+    if (memcmp(data + position, current, ((position + 4) > length) ? length - position : 4)) continue;
     for (count = 4; (count < (length - position)) && (count < (length - refpos)); count ++) if (data[position + count] != current[count]) break;
     if (count > (length - refpos)) count = length - refpos;
     if (count > (length - position)) count = length - position;

--- a/tools/lz/output.c
+++ b/tools/lz/output.c
@@ -28,8 +28,16 @@ void write_commands_and_padding_to_textfile (const char * file, const struct com
   if (fputs("\tlzend\n", fp) < 0) error_exit(1, "could not write terminator to compressed output");
   if (padding_size) {
     input_stream += padding_offset;
-    int rv = fprintf(fp, "\tdb $%02hhx", *(input_stream ++));
-    while ((rv >= 0) && (-- padding_size)) rv = fprintf(fp, ", $%02hhx", *(input_stream ++));
+    int rv = 0;
+    unsigned pos;
+    const char * prefix = "\tdb";
+    for (pos = 0; (rv >= 0) && (pos < padding_size); pos ++) {
+      if (input_stream[pos])
+        rv = fprintf(fp, "%s $%02hhx", prefix, input_stream[pos]);
+      else
+        rv = fprintf(fp, "%s 0", prefix);
+      prefix = ",";
+    }
     if (rv >= 0) rv = -(putc('\n', fp) == EOF);
     if (rv < 0) error_exit(1, "could not write padding to compressed output");
   }

--- a/tools/lz/uncomp.c
+++ b/tools/lz/uncomp.c
@@ -49,7 +49,7 @@ struct command * get_commands_from_file (const unsigned char * data, unsigned sh
   }
   if (slack) *slack = *size - (rp - data);
   *size = current - result;
-  return realloc(result, *size * sizeof(struct command));
+  return realloc(result, (*size ? *size : 1) * sizeof(struct command));
   error:
   free(result);
   return NULL;
@@ -88,5 +88,5 @@ unsigned char * get_uncompressed_data (const struct command * commands, const un
     }
   }
   *size = current - result;
-  return result;
+  return realloc(result, *size ? *size : 1);
 }


### PR DESCRIPTION
This PR also fixes the compression flags for a few files that had been misidentified, but matched due to undefined behavior in that uninitialized read.