### PR TITLE
Improved Virtual Console patch identifiers

### DIFF
--- a/engine/battle/battle_transition.asm
+++ b/engine/battle/battle_transition.asm
@@ -21,7 +21,7 @@ DoBattleTransition:
 	ld hl, hVBlank
 	ld a, [hl]
 	push af
-	vc_hook FPA_link_fight_begin
+	vc_hook Reduce_battle_transition_flashing
 	ld [hl], $1
 
 .loop
@@ -49,7 +49,7 @@ DoBattleTransition:
 	ldh [hSCY], a
 
 	pop af
-	vc_hook FPA_link_fight_End4
+	vc_hook Stop_reducing_battle_transition_flashing
 	ldh [hVBlank], a
 	call DelayFrame
 	ret
@@ -262,7 +262,7 @@ StartTrainerBattle_Flash:
 	dc 0, 0, 0, 1
 
 StartTrainerBattle_SetUpForWavyOutro:
-	vc_hook FPA_link_fight_End0
+	vc_hook Stop_reducing_battle_transition_flashing_WavyOutro
 	farcall RespawnPlayerAndOpponent
 
 	call StartTrainerBattle_NextScene
@@ -319,7 +319,7 @@ StartTrainerBattle_SineWave:
 	ret
 
 StartTrainerBattle_SetUpForSpinOutro:
-	vc_hook FPA_link_fight_End1
+	vc_hook Stop_reducing_battle_transition_flashing_SpinOutro
 	farcall RespawnPlayerAndOpponent
 	call StartTrainerBattle_NextScene
 	xor a
@@ -460,7 +460,7 @@ ENDM
 .wedge5: db 4, 0, 3, 0, 3, 0, 2, 0, 2, 0, 1, 0, 1, 0, 1, -1
 
 StartTrainerBattle_SetUpForRandomScatterOutro:
-	vc_hook FPA_link_fight_End2
+	vc_hook Stop_reducing_battle_transition_flashing_ScatterOutro
 	farcall RespawnPlayerAndOpponent
 	call StartTrainerBattle_NextScene
 	ld a, $10
@@ -679,7 +679,7 @@ StartTrainerBattle_DrawSineWave:
 	calc_sine_wave
 
 StartTrainerBattle_ZoomToBlack:
-	vc_hook	FPA_link_fight_End3
+	vc_hook	Stop_reducing_battle_transition_flashing_ZoomToBlack
 	farcall RespawnPlayerAndOpponent
 	ld de, .boxes
 

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -5671,7 +5671,7 @@ LinkBattleSendReceiveAction:
 
 .use_move
 	ld [wPlayerLinkAction], a
-	vc_hook send_byt2
+	vc_hook Wireless_start_exchange
 	callfar PlaceWaitingText
 
 .waiting
@@ -5681,8 +5681,8 @@ LinkBattleSendReceiveAction:
 	inc a
 	jr z, .waiting
 
-	vc_hook send_byt2_ret
-	vc_patch send_byt2_wait
+	vc_hook Wireless_end_exchange
+	vc_patch Wireless_net_delay_1
 if DEF(_GOLD_VC) || DEF(_SILVER_VC)
 	ld b, 26
 else
@@ -5695,8 +5695,8 @@ endc
 	dec b
 	jr nz, .receive
 
-	vc_hook send_dummy
-	vc_patch send_dummy_wait
+	vc_hook Wireless_start_send_zero_bytes
+	vc_patch Wireless_net_delay_2
 if DEF(_GOLD_VC) || DEF(_SILVER_VC)
 	ld b, 26
 else
@@ -5709,7 +5709,7 @@ endc
 	dec b
 	jr nz, .acknowledge
 
-	vc_hook send_dummy_end
+	vc_hook Wireless_end_send_zero_bytes
 	ret
 
 LoadEnemyMon:
@@ -8560,7 +8560,7 @@ InitBattleDisplay:
 	predef PlaceGraphic
 	xor a
 	ldh [hWY], a
-	vc_hook fight_begin
+	vc_hook Unknown_InitBattleDisplay
 	ldh [rWY], a
 	call WaitBGMap
 	call HideSprites

--- a/engine/battle_anims/anim_commands.asm
+++ b/engine/battle_anims/anim_commands.asm
@@ -648,7 +648,7 @@ BattleAnimCmd_5GFX:
 	xor a
 	ld [wBattleAnimGFXTempTileID], a
 .loop
-	vc_hook FPA_042801_Begin
+	vc_hook Reduce_move_anim_flashing_PRESENT
 	ld a, [wBattleAnimGFXTempTileID]
 	cp (vTiles1 - vTiles0) / LEN_2BPP_TILE - BATTLEANIM_BASE_TILE
 	ret nc

--- a/engine/events/print_unown.asm
+++ b/engine/events/print_unown.asm
@@ -74,7 +74,7 @@ _UnownPrinter:
 	jr nz, .pressed_b
 
 	ldh a, [hJoyPressed]
-	vc_patch print_forbid_1
+	vc_patch Forbid_printing_Unown
 if DEF(_GOLD_VC) || DEF(_SILVER_VC)
 	and 0
 else

--- a/engine/gfx/color.asm
+++ b/engine/gfx/color.asm
@@ -761,7 +761,7 @@ _PushSGBPals:
 
 InitSGBBorder:
 	call CheckCGB
-	vc_hook Network_RESET
+	vc_hook Unknown_network_reset
 	ret nz
 
 ; SGB/DMG only

--- a/engine/link/link.asm
+++ b/engine/link/link.asm
@@ -65,7 +65,7 @@ Gen2ToGen1LinkComms:
 .player_1
 	ld de, MUSIC_NONE
 	call PlayMusic
-	vc_patch NetworkDelay1
+	vc_patch Wireless_net_delay_5
 if DEF(_GOLD_VC) || DEF(_SILVER_VC)
 	ld c, 26
 else
@@ -81,7 +81,7 @@ endc
 	ld hl, wLinkBattleRNPreamble
 	ld de, wEnemyMon
 	ld bc, SERIAL_RN_PREAMBLE_LENGTH + SERIAL_RNS_LENGTH
-	vc_hook Network358
+	vc_hook Wireless_ExchangeBytes_1
 	call Serial_ExchangeBytes
 	ld a, SERIAL_NO_DATA_BYTE
 	ld [de], a
@@ -89,7 +89,7 @@ endc
 	ld hl, wLinkData
 	ld de, wOTPartyData
 	ld bc, SERIAL_PREAMBLE_LENGTH + NAME_LENGTH + 1 + PARTY_LENGTH + 1 + (REDMON_STRUCT_LENGTH + NAME_LENGTH * 2) * PARTY_LENGTH + 3
-	vc_hook Network359
+	vc_hook Wireless_ExchangeBytes_2
 	call Serial_ExchangeBytes
 	ld a, SERIAL_NO_DATA_BYTE
 	ld [de], a
@@ -97,7 +97,7 @@ endc
 	ld hl, wPlayerPatchLists
 	ld de, wOTPatchLists
 	ld bc, 200
-	vc_hook Network364
+	vc_hook Wireless_ExchangeBytes_3_Gen2toGen1Fix
 	call Serial_ExchangeBytes
 
 	xor a
@@ -231,7 +231,7 @@ Gen2ToGen2LinkComms:
 .player_1
 	ld de, MUSIC_NONE
 	call PlayMusic
-	vc_patch NetworkDelay4
+	vc_patch Wireless_net_delay_8
 if DEF(_GOLD_VC) || DEF(_SILVER_VC)
 	ld c, 26
 else
@@ -247,7 +247,7 @@ endc
 	ld hl, wLinkBattleRNPreamble
 	ld de, wEnemyMon
 	ld bc, SERIAL_RN_PREAMBLE_LENGTH + SERIAL_RNS_LENGTH
-	vc_hook Network360
+	vc_hook Wireless_ExchangeBytes_4
 	call Serial_ExchangeBytes
 	ld a, SERIAL_NO_DATA_BYTE
 	ld [de], a
@@ -255,7 +255,7 @@ endc
 	ld hl, wLinkData
 	ld de, wOTPartyData
 	ld bc, SERIAL_PREAMBLE_LENGTH + NAME_LENGTH + 1 + PARTY_LENGTH + 1 + 2 + (PARTYMON_STRUCT_LENGTH + NAME_LENGTH * 2) * PARTY_LENGTH + 3
-	vc_hook Network361
+	vc_hook Wireless_ExchangeBytes_5
 	call Serial_ExchangeBytes
 	ld a, SERIAL_NO_DATA_BYTE
 	ld [de], a
@@ -263,7 +263,7 @@ endc
 	ld hl, wPlayerPatchLists
 	ld de, wOTPatchLists
 	ld bc, 200
-	vc_hook Network362
+	vc_hook Wireless_ExchangeBytes_6
 	call Serial_ExchangeBytes
 
 	ld a, [wLinkMode]
@@ -272,7 +272,7 @@ endc
 	ld hl, wLinkPlayerMail
 	ld de, wLinkOTMail
 	ld bc, wLinkPlayerMailEnd - wLinkPlayerMail
-	vc_hook Network363
+	vc_hook Wireless_ExchangeBytes_7
 	call ExchangeBytes
 
 .not_trading
@@ -1482,7 +1482,7 @@ ExitLinkCommunications:
 	ldh [rSC], a
 	ld a, (1 << rSC_ON) | (1 << rSC_CLOCK)
 	ldh [rSC], a
-	vc_hook ret_heya
+	vc_hook ExitLinkCommunications_ret
 	ret
 
 PlaceTradeScreenFooter:
@@ -1860,7 +1860,7 @@ LinkTrade:
 	hlcoord 1, 14
 	ld de, String_TradeCompleted
 	call PlaceString
-	vc_hook save_game_end
+	vc_hook Trade_save_game_end
 	ld c, 50
 	call DelayFrames
 	ld a, [wLinkMode]
@@ -2048,7 +2048,7 @@ GetIncompatibleMonName:
 	ret
 
 EnterTimeCapsule:
-	vc_patch NetworkDelay2
+	vc_patch Wireless_net_delay_6
 if DEF(_GOLD_VC) || DEF(_SILVER_VC)
 	ld c, 26
 	call DelayFrames
@@ -2104,7 +2104,7 @@ WaitForOtherPlayerToExit:
 	ld [hl], a
 	ldh [hVBlank], a
 	ld [wLinkMode], a
-	vc_hook term_exit
+	vc_hook Wireless_term_exit
 	ret
 
 SetBitsForLinkTradeRequest:
@@ -2173,7 +2173,7 @@ WaitForLinkedFriend:
 ; USING_INTERNAL_CLOCK, which allows the player to proceed past the link
 ; receptionist's "Please wait." It assumes that hSerialConnectionStatus is at
 ; its original address.
-	vc_hook linkCable_fake_begin
+	vc_hook Link_fake_connection_status
 	vc_assert hSerialConnectionStatus == $ffcd, \
 		"hSerialConnectionStatus is no longer located at 00:ffcd"
 	vc_assert USING_INTERNAL_CLOCK == $02, \
@@ -2270,7 +2270,7 @@ CheckLinkTimeout_Gen2:
 	ld a, $6
 	ld [wPlayerLinkAction], a
 	ld hl, wLinkTimeoutFrames
-	vc_patch NetworkDelay6
+	vc_patch Wireless_net_delay_9
 if DEF(_GOLD_VC) || DEF(_SILVER_VC)
 	ld a, 3
 else
@@ -2297,11 +2297,11 @@ endc
 Link_CheckCommunicationError:
 	xor a
 	ldh [hSerialReceivedNewData], a
-	vc_hook linkCable_fake_end
+	vc_hook Wireless_prompt
 	call WaitLinkTransfer
 
 	ld hl, wLinkTimeoutFrames
-	vc_hook Network_RECHECK
+	vc_hook Wireless_net_recheck
 	ld a, [hli]
 	inc a
 	jr nz, .load_true
@@ -2309,7 +2309,7 @@ Link_CheckCommunicationError:
 	inc a
 	jr nz, .load_true
 
-	vc_patch NetworkDelay3
+	vc_patch Wireless_net_delay_7
 if DEF(_GOLD_VC) || DEF(_SILVER_VC)
 	ld b, 26
 else
@@ -2341,10 +2341,10 @@ TryQuickSave:
 	ld a, [wChosenCableClubRoom]
 	push af
 	farcall Link_SaveGame
-	vc_hook linkCable_block_input
+	vc_hook Wireless_TryQuickSave_block_input_1
 	ld a, TRUE
 	jr nc, .return_result
-	vc_hook linkCable_block_input2
+	vc_hook Wireless_TryQuickSave_block_input_2
 	xor a ; FALSE
 .return_result
 	ld [wScriptVar], a
@@ -2381,7 +2381,7 @@ CheckBothSelectedSameRoom:
 	ret
 
 TimeCapsule:
-	vc_hook to_play2_mons1
+	vc_hook Wireless_TimeCapsule
 	ld a, LINK_TIMECAPSULE
 	ld [wLinkMode], a
 	call DisableSpriteUpdates
@@ -2392,7 +2392,7 @@ TimeCapsule:
 	ret
 
 TradeCenter:
-	vc_hook to_play2_trade
+	vc_hook Wireless_TradeCenter
 	ld a, LINK_TRADECENTER
 	ld [wLinkMode], a
 	call DisableSpriteUpdates
@@ -2403,7 +2403,7 @@ TradeCenter:
 	ret
 
 Colosseum:
-	vc_hook to_play2_battle
+	vc_hook Wireless_Colosseum
 	ld a, LINK_COLOSSEUM
 	ld [wLinkMode], a
 	call DisableSpriteUpdates
@@ -2416,7 +2416,7 @@ Colosseum:
 CloseLink:
 	ld c, 3
 	call DelayFrames
-	vc_hook room_check
+	vc_hook Wireless_room_check
 	jp Link_ResetSerialRegistersAfterLinkClosure
 
 FailedLinkToPast:

--- a/engine/link/mystery_gift.asm
+++ b/engine/link/mystery_gift.asm
@@ -35,7 +35,7 @@ DoMysteryGift:
 	; Prepare the first of two messages for wMysteryGiftPartnerData
 	farcall StageDataForMysteryGift
 	call ClearMysteryGiftTrainer
-	vc_patch infrared_fake_0
+	vc_patch Infrared_stage_party_data
 if DEF(_GOLD_VC) || DEF(_SILVER_VC)
 	farcall StagePartyDataForMysteryGift
 	call ClearMysteryGiftTrainer
@@ -51,7 +51,7 @@ endc
 	ldh a, [rIE]
 	push af
 	call ExchangeMysteryGiftData
-	vc_hook infrared_fake_4
+	vc_hook Infrared_ExchangeMysteryGiftData_end
 	ld d, a
 	xor a
 	ldh [rIF], a
@@ -265,10 +265,11 @@ endc
 
 ExchangeMysteryGiftData:
 	farcall ClearChannels
-	vc_patch infrared_fake
+	vc_hook Infrared_ExchangeMysteryGiftData_start
+	vc_patch Infrared_ExchangeMysteryGiftData_function
 if DEF(_GOLD_VC) || DEF(_SILVER_VC)
 	nop
-	vc_hook infrared_fake_5
+	vc_hook Infrared_ExchangeMysteryGiftData_unknown_Mode100
 	nop
 	nop
 
@@ -279,7 +280,7 @@ if DEF(_GOLD_VC) || DEF(_SILVER_VC)
 	ld a, d
 	or a
 	jr nz, .loop
-	vc_hook infrared_fake_3
+	vc_hook Infrared_ExchangeMysteryGiftData_loop_done
 	nop
 	cp MG_CANCELED
 	ret z

--- a/engine/menus/menu.asm
+++ b/engine/menus/menu.asm
@@ -215,7 +215,7 @@ _ScrollingMenuJoypad::
 	jr .loopRTC
 
 .pressed
-	vc_hook print_forbid_3
+	vc_hook Forbid_printing_photo_studio
 	call _2DMenuInterpretJoypad
 	jp c, .done
 	ld a, [w2DMenuFlags1]
@@ -245,7 +245,7 @@ Menu_WasButtonPressed:
 	and a
 	ret z
 	scf
-	vc_hook print_forbid_2
+	vc_hook Forbid_printing_PC_Box
 	ret
 
 _2DMenuInterpretJoypad:

--- a/engine/overworld/scripting.asm
+++ b/engine/overworld/scripting.asm
@@ -370,7 +370,7 @@ Script_yesorno:
 	ld a, TRUE
 .no
 	ld [wScriptVar], a
-	vc_hook E_YESNO
+	vc_hook Unknown_yesorno_ret
 	ret
 
 Script_loadmenu:

--- a/engine/pokedex/pokedex.asm
+++ b/engine/pokedex/pokedex.asm
@@ -356,7 +356,7 @@ Pokedex_UpdateDexEntryScreen:
 	ld a, [hl]
 	and B_BUTTON
 	jr nz, .return_to_prev_screen
-	vc_hook print_forbid_5
+	vc_hook Forbid_printing_Pokedex
 	ld a, [hl]
 	and A_BUTTON
 	jr nz, .do_menu_action

--- a/engine/pokemon/mail_2.asm
+++ b/engine/pokemon/mail_2.asm
@@ -48,7 +48,7 @@ ReadAnyMail:
 	ldh a, [hJoyPressed]
 	and A_BUTTON | B_BUTTON | START
 	jr z, .loop
-	vc_patch print_forbid_4
+	vc_patch Forbid_printing_mail
 if DEF(_GOLD_VC) || DEF(_SILVER_VC)
 	and 0
 else

--- a/home/serial.asm
+++ b/home/serial.asm
@@ -282,7 +282,7 @@ Serial_SyncAndExchangeNybble:: ; unreferenced
 	jp WaitLinkTransfer ; pointless
 
 WaitLinkTransfer::
-	vc_hook send_send_buf2
+	vc_hook Wireless_WaitLinkTransfer
 	ld a, $ff
 	ld [wOtherPlayerLinkAction], a
 .loop
@@ -310,7 +310,7 @@ WaitLinkTransfer::
 	inc a
 	jr z, .loop
 
-	vc_patch Network10
+	vc_patch Wireless_net_delay_3
 if DEF(_GOLD_VC) || DEF(_SILVER_VC)
 	ld b, 26
 else
@@ -323,7 +323,7 @@ endc
 	dec b
 	jr nz, .receive
 
-	vc_patch Network11
+	vc_patch Wireless_net_delay_4
 if DEF(_GOLD_VC) || DEF(_SILVER_VC)
 	ld b, 26
 else
@@ -338,7 +338,7 @@ endc
 
 	ld a, [wOtherPlayerLinkAction]
 	ld [wOtherPlayerLinkMode], a
-	vc_hook send_send_buf2_ret
+	vc_hook Wireless_WaitLinkTransfer_ret
 	ret
 
 LinkTransfer::

--- a/vc/pokegold.patch.template
+++ b/vc/pokegold.patch.template
@@ -29,117 +29,117 @@
 
 
 
-[send_send_buf2]
+[send_send_buf2@Wireless_WaitLinkTransfer]
 Mode = 2
 Address = {HEX @ 4}
 Type = 29
 
-[send_send_buf2_ret]
+[send_send_buf2_ret@Wireless_WaitLinkTransfer_ret]
 Mode = 2
 Address = {HEX @ 4}
 Type = 30
 
-[send_byt2]
+[send_byt2@Wireless_start_exchange]
 Mode = 2
 Address = {HEX @+5}
 Type = 31
 
-[send_byt2_ret]
+[send_byt2_ret@Wireless_end_exchange]
 Mode = 2
 Address = {HEX @}
 Type = 32
 
-[send_byt2_wait]
+[send_byt2_wait@Wireless_net_delay_1]
 Mode = 1
 Address = {HEX @+1}
 Fixcode = {PATCH +1}
 
-[send_dummy]
+[send_dummy@Wireless_start_send_zero_bytes]
 Mode = 2
 Address = {HEX @}
 Type = 33
 
-[send_dummy_wait]
+[send_dummy_wait@Wireless_net_delay_2]
 Mode = 1
 Address = {HEX @+1}
 Fixcode = {PATCH +1}
 
-[send_dummy_end]
+[send_dummy_end@Wireless_end_send_zero_bytes]
 Mode = 2
 Address = {HEX @}
 Type = 34
 
-[Network10]
+[Network10@Wireless_net_delay_3]
 Mode = 1
 Address = {HEX @+1 4}
 Fixcode = {PATCH +1}
 
-[Network11]
+[Network11@Wireless_net_delay_4]
 Mode = 1
 Address = {HEX @+1 4}
 Fixcode = {PATCH +1}
 
-[NetworkDelay1]
+[NetworkDelay1@Wireless_net_delay_5]
 Mode = 1
 Address = {HEX @+1}
 Fixcode = {PATCH +1}
 
-[NetworkDelay2]
+[NetworkDelay2@Wireless_net_delay_6]
 Mode = 1
 Address = {HEX @}
 Fixcode = {PATCH}
 
-[NetworkDelay3]
+[NetworkDelay3@Wireless_net_delay_7]
 Mode = 1
 Address = {HEX @+1}
 Fixcode = {PATCH +1}
 
-[NetworkDelay4]
+[NetworkDelay4@Wireless_net_delay_8]
 Mode = 1
 Address = {HEX @+1}
 Fixcode = {PATCH +1}
 
-[NetworkDelay6]
+[NetworkDelay6@Wireless_net_delay_9]
 Mode = 1
 Address = {HEX @+1}
 Fixcode = {PATCH +1}
 
-[Network358]
+[Network358@Wireless_ExchangeBytes_1]
 Mode = 2
 Address = {HEX @}
 Type = 4
 
-[Network359]
+[Network359@Wireless_ExchangeBytes_2]
 Mode = 2
 Address = {HEX @}
 Type = 4
 
-[Network364]
+[Network364@Wireless_ExchangeBytes_3_Gen2toGen1Fix]
 Mode = 2
 Address = {HEX @}
 Type = 26
 
-[Network360]
+[Network360@Wireless_ExchangeBytes_4]
 Mode = 2
 Address = {HEX @}
 Type = 4
 
-[Network361]
+[Network361@Wireless_ExchangeBytes_5]
 Mode = 2
 Address = {HEX @}
 Type = 4
 
-[Network362]
+[Network362@Wireless_ExchangeBytes_6]
 Mode = 2
 Address = {HEX @}
 Type = 4
 
-[Network363]
+[Network363@Wireless_ExchangeBytes_7]
 Mode = 2
 Address = {HEX @}
 Type = 4
 
-[Network_RECHECK]
+[Network_RECHECK@Wireless_net_recheck]
 Mode = 2
 Address = {HEX @}
 Type = 7
@@ -154,60 +154,60 @@ Type = 7
 ;Address = 0xF4D3C
 ;Type = 9
 
-[Network_RESET]
+[Network_RESET@Unknown_network_reset]
 Mode = 2
 Address = {HEX @ 5}
 Type = 10
 
-[E_YESNO]
+[E_YESNO@Unknown_yesorno_ret]
 Mode = 2
 Address = {HEX @}
 Type = 15
 
-[linkCable fake begin]
+[linkCable fake begin@Link_fake_connection_status]
 Mode = 2
 Address = {HEX @}
 Type = 16
 
-[linkCable fake end]
+[linkCable fake end@Wireless_prompt]
 Mode = 2
 Address = {HEX @}
 Type = 17  
 
 ;MURIYARI
-[linkCable block input]
+[linkCable block input@Wireless_TryQuickSave_block_input_1]
 Mode = 2
 Address = {HEX @}
 Type = 18
-[linkCable block input2]
+[linkCable block input2@Wireless_TryQuickSave_block_input_2]
 Mode = 2
 Address = {HEX @}
 Type = 24
-[save game end]
+[save game end@Trade_save_game_end]
 Mode = 2
 Address = {HEX @}
 Type = 20
-[term_exit]
+[term_exit@Wireless_term_exit]
 Mode = 2
 Address = {HEX @}
 Type = 25
-[room_check]
+[room_check@Wireless_room_check]
 Mode = 2
 Address = {HEX @}
 Type = 27
-[to_play2_mons1]
+[to_play2_mons1@Wireless_TimeCapsule]
 Mode = 2
 Address = {HEX @}
 Type = 11
-[to_play2_trade]
+[to_play2_trade@Wireless_TradeCenter]
 Mode = 2
 Address = {HEX @}
 Type = 12
-[to_play2_battle]
+[to_play2_battle@Wireless_Colosseum]
 Mode = 2
 Address = {HEX @}
 Type = 13
-[ret_heya]
+[ret_heya@ExitLinkCommunications_ret]
 Mode = 2
 Address = {HEX @}
 Type = 14
@@ -409,7 +409,7 @@ ConditionValueC = {dws_ "F"            "L"              "A"              "S"    
  ; ******0xcccccccccffffffff8***********---------------   Mem Write: pc32 = 0x3180 addr = 0xcf85 value = 0x50
  
                                                                                                                                                 
-[FPA 042801 Begin]                                                                                                                               
+[FPA 042801 Begin@Reduce_move_anim_flashing_PRESENT]                                                                                                                               
 Mode = 3                                                                                                                                         
 Type = 0                                                                                                                                         
 Address = {HEX @}                                                                                                                              
@@ -444,7 +444,7 @@ Address = {hex @}
 
 ;******ffa0***000000000000---------------   Mem Write: pc32 = 0x8c52d addr = 0xffa0 value = 0x1
 ;-----ddddff0xff690xff69fffff----0xce57 no ....----5555555577777---------..........Mem Write: pc32 = 0x8c483 addr = 0xce57 value = 0x1a
-[FPA link fight begin]
+[FPA link fight begin@Reduce_battle_transition_flashing]
 Mode = 3                                                          
 Type = 0                                                          
 Address = {hex @}
@@ -465,30 +465,30 @@ MotionBlur0 = 11
 ;******cccceeee6333---------------   Mem Write: pc32 = 0x8c65e addr = 0xce63 value = 0x17 
 
 ;40 90 e4 01 3E at 3E
-[FPA link fight End0]                                                     
+[FPA link fight End0@Stop_reducing_battle_transition_flashing_WavyOutro]                                                     
 Mode = 3                                                          
 Type = 1                                                          
 Address = {HEX @}
 
 ;3D 20 EF C9 3E 01 at 3E
-[FPA link fight End1]                                                     
+[FPA link fight End1@Stop_reducing_battle_transition_flashing_SpinOutro]                                                     
 Mode = 3                                                          
 Type = 1                                                          
 Address = {HEX @}
 
 ;01 FF 3E 01 at 3E
-[FPA link fight End2]                                                     
+[FPA link fight End2@Stop_reducing_battle_transition_flashing_ScatterOutro]                                                     
 Mode = 3                                                          
 Type = 1                                                          
 Address = {HEX @}  
 
 ;32 00 19 00 3e 01 at 3e
-[FPA link fight End3]                                                     
+[FPA link fight End3@Stop_reducing_battle_transition_flashing_ZoomToBlack]                                                     
 Mode = 3                                                          
 Type = 1                                                          
 Address = {HEX @}
 
-[FPA link fight End4]                                                     
+[FPA link fight End4@Stop_reducing_battle_transition_flashing]                                                     
 Mode = 3                                                          
 Type = 1                                                          
 Address = {hex @} 
@@ -516,7 +516,7 @@ Address = {hex @}
 
 ;0003f8c6h: AF E0 D4 E0 4A                                  ; 脏J
 
-[fight begin]                        
+[fight begin@Unknown_InitBattleDisplay]                        
 Mode = 11                       
 Type = 0                        
 Index = 1                       
@@ -536,7 +536,7 @@ Fixcode={db SCREEN_HEIGHT_PX}
 ;    
 ; change "and 1" to "and 0"
 ;00016ecch: E6 01 20 08                                 
-[print forbid 1]                                                   
+[print forbid 1@Forbid_printing_Unown]                                                   
 Mode = 1                                                                                                                  
 Address = {hex @}
 Fixcode={patch}     
@@ -573,7 +573,7 @@ Fixcode={patch}
 ;0002419bh: C9 CD 7A 1A CB 47 C2 44 42 CB 4F C2 44 42 CB 57 
 ;000241abh: C2 44 42 CB                                     
 ;                            
-[print forbid 2]                                                                           
+[print forbid 2@Forbid_printing_PC_Box]                                                                           
 Mode = 6                                                                                       
 Type = 0                                                                                       
 Address = {hex @}                                                                          
@@ -588,7 +588,7 @@ ConditionValueC = {dws_ 0xb7                0xb9                  A_BUTTON    0x
 ; 0xd9c7 is the room number.
 ;
 
-[print forbid 3]                                                          
+[print forbid 3@Forbid_printing_photo_studio]                                                          
 Mode = 6                                                                      
 Type = 0                                                                      
 Address = {hex @}                                                             
@@ -608,7 +608,7 @@ ConditionValueC = {dws_ 0xcd                0xbf                  NO_INPUT    0x
 ;ROM:BB2A9                 ret    
 ; 000baf1ah: E6 08 20 01                                     
 ; change "and 1" to "and 0"                                                      
-[print forbid 4]                                                  
+[print forbid 4@Forbid_printing_mail]                                                  
 Mode = 1                                                          
 Address = {hex @}                                               
 Fixcode={patch}            
@@ -629,7 +629,7 @@ Fixcode={patch}
 ; -----6666666666ddddddddd88888----0xc6d8 no ..............Mem Write: pc32 = 0x4109b addr = 0xc6d8 value = 0x0
 
 ; 00040266h: 7E E6 01 20 08                            
-[print forbid 5]                                                                                           
+[print forbid 5@Forbid_printing_Pokedex]                                                                                           
 Mode = 6                                                                                          
 Type = 0                                                                                          
 Address = {hex @}                                                                                
@@ -669,7 +669,7 @@ ConditionValueC = {dws_ 0xbd                0xbd                  A_BUTTON    0x
 ;
 
 ;00029e23h: 3E 02 EA 01 C9                                      
-[infrared fake 0]                                                  
+[infrared fake 0@Infrared_stage_party_data]                                                  
 Mode = 1                                                          
 Address = {hex @}                                        
 Fixcode={PATCH}  
@@ -679,27 +679,27 @@ Fixcode={PATCH}
 ;00029fc8h: 30 3E 3A 21 E9 4F CF CD 8C 61 CD C4 61 CD 0B 62 
 ;00029fd8h: F0 BE FE 10                                     
                                 
-[infrared fake 1@infrared_fake]                                                  
+[infrared fake 1@Infrared_ExchangeMysteryGiftData_function]                                                  
 Mode = 1                                                          
 Address = {hex @}                                      
 Fixcode={patch 0 21}      
 
-[infrared fake 2@infrared_fake]                    
+[infrared fake 2@Infrared_ExchangeMysteryGiftData_start]                    
 Mode = 2                             
 Address = {hex @}                    
 Type = 101    
 
-[infrared fake 5]          
+[infrared fake 5@Infrared_ExchangeMysteryGiftData_unknown_Mode100]          
 Mode = 2                   
 Address = {hex @}         
 Type = 100                                       
                                      
-[infrared fake 3]                    
+[infrared fake 3@Infrared_ExchangeMysteryGiftData_loop_done]                    
 Mode = 2                             
 Address = {hex @}                    
 Type = 102                           
                                      
-[infrared fake 4]                    
+[infrared fake 4@Infrared_ExchangeMysteryGiftData_end]                    
 Mode = 2                             
 Address = {hex @}                   
 Type = 103                           

--- a/vc/pokesilver.patch.template
+++ b/vc/pokesilver.patch.template
@@ -29,117 +29,117 @@
 
 
 
-[send_send_buf2]
+[send_send_buf2@Wireless_WaitLinkTransfer]
 Mode = 2
 Address = {HEX @ 4}
 Type = 29
 
-[send_send_buf2_ret]
+[send_send_buf2_ret@Wireless_WaitLinkTransfer_ret]
 Mode = 2
 Address = {HEX @ 4}
 Type = 30
 
-[send_byt2]
+[send_byt2@Wireless_start_exchange]
 Mode = 2
 Address = {HEX @+5}
 Type = 31
 
-[send_byt2_ret]
+[send_byt2_ret@Wireless_end_exchange]
 Mode = 2
 Address = {HEX @}
 Type = 32
 
-[send_byt2_wait]
+[send_byt2_wait@Wireless_net_delay_1]
 Mode = 1
 Address = {HEX @+1}
 Fixcode = {PATCH +1}
 
-[send_dummy]
+[send_dummy@Wireless_start_send_zero_bytes]
 Mode = 2
 Address = {HEX @}
 Type = 33
 
-[send_dummy_wait]
+[send_dummy_wait@Wireless_net_delay_2]
 Mode = 1
 Address = {HEX @+1}
 Fixcode = {PATCH +1}
 
-[send_dummy_end]
+[send_dummy_end@Wireless_end_send_zero_bytes]
 Mode = 2
 Address = {HEX @}
 Type = 34
 
-[Network10]
+[Network10@Wireless_net_delay_3]
 Mode = 1
 Address = {HEX @+1 4}
 Fixcode = {PATCH +1}
 
-[Network11]
+[Network11@Wireless_net_delay_4]
 Mode = 1
 Address = {HEX @+1 4}
 Fixcode = {PATCH +1}
 
-[NetworkDelay1]
+[NetworkDelay1@Wireless_net_delay_5]
 Mode = 1
 Address = {HEX @+1}
 Fixcode = {PATCH +1}
 
-[NetworkDelay2]
+[NetworkDelay2@Wireless_net_delay_6]
 Mode = 1
 Address = {HEX @}
 Fixcode = {PATCH}
 
-[NetworkDelay3]
+[NetworkDelay3@Wireless_net_delay_7]
 Mode = 1
 Address = {HEX @+1}
 Fixcode = {PATCH +1}
 
-[NetworkDelay4]
+[NetworkDelay4@Wireless_net_delay_8]
 Mode = 1
 Address = {HEX @+1}
 Fixcode = {PATCH +1}
 
-[NetworkDelay6]
+[NetworkDelay6@Wireless_net_delay_9]
 Mode = 1
 Address = {HEX @+1}
 Fixcode = {PATCH +1}
 
-[Network358]
+[Network358@Wireless_ExchangeBytes_1]
 Mode = 2
 Address = {HEX @}
 Type = 4
 
-[Network359]
+[Network359@Wireless_ExchangeBytes_2]
 Mode = 2
 Address = {HEX @}
 Type = 4
 
-[Network364]
+[Network364@Wireless_ExchangeBytes_3_Gen2toGen1Fix]
 Mode = 2
 Address = {HEX @}
 Type = 26
 
-[Network360]
+[Network360@Wireless_ExchangeBytes_4]
 Mode = 2
 Address = {HEX @}
 Type = 4
 
-[Network361]
+[Network361@Wireless_ExchangeBytes_5]
 Mode = 2
 Address = {HEX @}
 Type = 4
 
-[Network362]
+[Network362@Wireless_ExchangeBytes_6]
 Mode = 2
 Address = {HEX @}
 Type = 4
 
-[Network363]
+[Network363@Wireless_ExchangeBytes_7]
 Mode = 2
 Address = {HEX @}
 Type = 4
 
-[Network_RECHECK]
+[Network_RECHECK@Wireless_net_recheck]
 Mode = 2
 Address = {HEX @}
 Type = 7
@@ -154,60 +154,60 @@ Type = 7
 ;Address = 0xF4D3C
 ;Type = 9
 
-[Network_RESET]
+[Network_RESET@Unknown_network_reset]
 Mode = 2
 Address = {HEX @ 5}
 Type = 10
 
-[E_YESNO]
+[E_YESNO@Unknown_yesorno_ret]
 Mode = 2
 Address = {HEX @}
 Type = 15
 
-[linkCable fake begin]
+[linkCable fake begin@Link_fake_connection_status]
 Mode = 2
 Address = {HEX @}
 Type = 16
 
-[linkCable fake end]
+[linkCable fake end@Wireless_prompt]
 Mode = 2
 Address = {HEX @}
 Type = 17  
 
 ;MURIYARI
-[linkCable block input]
+[linkCable block input@Wireless_TryQuickSave_block_input_1]
 Mode = 2
 Address = {HEX @}
 Type = 18
-[linkCable block input2]
+[linkCable block input2@Wireless_TryQuickSave_block_input_2]
 Mode = 2
 Address = {HEX @}
 Type = 24
-[save game end]
+[save game end@Trade_save_game_end]
 Mode = 2
 Address = {HEX @}
 Type = 20
-[term_exit]
+[term_exit@Wireless_term_exit]
 Mode = 2
 Address = {HEX @}
 Type = 25
-[room_check]
+[room_check@Wireless_room_check]
 Mode = 2
 Address = {HEX @}
 Type = 27
-[to_play2_mons1]
+[to_play2_mons1@Wireless_TimeCapsule]
 Mode = 2
 Address = {HEX @}
 Type = 11
-[to_play2_trade]
+[to_play2_trade@Wireless_TradeCenter]
 Mode = 2
 Address = {HEX @}
 Type = 12
-[to_play2_battle]
+[to_play2_battle@Wireless_Colosseum]
 Mode = 2
 Address = {HEX @}
 Type = 13
-[ret_heya]
+[ret_heya@ExitLinkCommunications_ret]
 Mode = 2
 Address = {HEX @}
 Type = 14
@@ -414,7 +414,7 @@ ConditionValueC = {dws_ "F"            "L"              "A"              "S"    
  ; ******0xcccccccccffffffff8***********---------------   Mem Write: pc32 = 0x3180 addr = 0xcf85 value = 0x50
  
                                                                                                                                                 
-[FPA 042801 Begin]                                                                                                                               
+[FPA 042801 Begin@Reduce_move_anim_flashing_PRESENT]                                                                                                                               
 Mode = 3                                                                                                                                         
 Type = 0                                                                                                                                         
 Address = {HEX @}                                                                                                                              
@@ -448,7 +448,7 @@ Address = {hex @}
 
 ;******ffa0***000000000000---------------   Mem Write: pc32 = 0x8c52d addr = 0xffa0 value = 0x1
 ;-----ddddff0xff690xff69fffff----0xce57 no ....----5555555577777---------..........Mem Write: pc32 = 0x8c483 addr = 0xce57 value = 0x1a
-[FPA link fight begin]
+[FPA link fight begin@Reduce_battle_transition_flashing]
 Mode = 3                                                          
 Type = 0                                                          
 Address = {hex @}
@@ -471,30 +471,30 @@ MotionBlur0 = 11
 
 
 ;40 90 e4 01 3E at 3E
-[FPA link fight End0]                                                     
+[FPA link fight End0@Stop_reducing_battle_transition_flashing_WavyOutro]                                                     
 Mode = 3                                                          
 Type = 1                                                          
 Address = {HEX @}
 
 ;3D 20 EF C9 3E 01 at 3E
-[FPA link fight End1]                                                     
+[FPA link fight End1@Stop_reducing_battle_transition_flashing_SpinOutro]                                                     
 Mode = 3                                                          
 Type = 1                                                          
 Address = {HEX @}
 
 ;01 FF 3E 01 at 3E
-[FPA link fight End2]                                                     
+[FPA link fight End2@Stop_reducing_battle_transition_flashing_ScatterOutro]                                                     
 Mode = 3                                                          
 Type = 1                                                          
 Address = {HEX @}  
 
 ;32 00 19 00 3e 01 at 3e
-[FPA link fight End3]                                                     
+[FPA link fight End3@Stop_reducing_battle_transition_flashing_ZoomToBlack]                                                     
 Mode = 3                                                          
 Type = 1                                                          
 Address = {HEX @}
 
-[FPA link fight End4]                                                     
+[FPA link fight End4@Stop_reducing_battle_transition_flashing]                                                     
 Mode = 3                                                          
 Type = 1                                                          
 Address = {hex @} 
@@ -521,7 +521,7 @@ Address = {hex @}
 ;ROM:3F93D                 xor     a     
 ;0003f8c6h: AF E0 D4 E0 4A                            
 
-[fight begin]                        
+[fight begin@Unknown_InitBattleDisplay]                        
 Mode = 11                       
 Type = 0                        
 Index = 1                       
@@ -544,7 +544,7 @@ Fixcode={db SCREEN_HEIGHT_PX}
 ;    
 ; change "and 1" to "and 0"
 ;00016ecch: E6 01 20 08                                 
-[print forbid 1]                                                   
+[print forbid 1@Forbid_printing_Unown]                                                   
 Mode = 1                                                                                                                  
 Address = {hex @}
 Fixcode={patch}     
@@ -581,7 +581,7 @@ Fixcode={patch}
 ;0002419bh: C9 CD 7A 1A CB 47 C2 44 42 CB 4F C2 44 42 CB 57 
 ;000241abh: C2 44 42 CB                                     
 ;                            
-[print forbid 2]                                                                           
+[print forbid 2@Forbid_printing_PC_Box]                                                                           
 Mode = 6                                                                                       
 Type = 0                                                                                       
 Address = {hex @}                                                                          
@@ -596,7 +596,7 @@ ConditionValueC = {dws_ 0xb7                0xb9                  A_BUTTON    0x
 ; 0xd9c7 is the room number.
 ;
 
-[print forbid 3]                                                          
+[print forbid 3@Forbid_printing_photo_studio]                                                          
 Mode = 6                                                                      
 Type = 0                                                                      
 Address = {hex @}                                                             
@@ -616,7 +616,7 @@ ConditionValueC = {dws_ 0xcd                0xbf                  NO_INPUT    0x
 ;ROM:BB2A9                 ret    
 ; 000baf1ah: E6 08 20 01                                     
 ; change "and 1" to "and 0"                                                      
-[print forbid 4]                                                  
+[print forbid 4@Forbid_printing_mail]                                                  
 Mode = 1                                                          
 Address = {hex @}                                               
 Fixcode={patch}            
@@ -637,7 +637,7 @@ Fixcode={patch}
 ; -----6666666666ddddddddd88888----0xc6d8 no ..............Mem Write: pc32 = 0x4109b addr = 0xc6d8 value = 0x0
 
 ; 00040266h: 7E E6 01 20 08                            
-[print forbid 5]                                                                                           
+[print forbid 5@Forbid_printing_Pokedex]                                                                                           
 Mode = 6                                                                                          
 Type = 0                                                                                          
 Address = {hex @}                                                                                
@@ -678,7 +678,7 @@ ConditionValueC = {dws_ 0xbd                0xbd                  A_BUTTON    0x
 ;
 
 ;00029e23h: 3E 02 EA 01 C9                                      
-[infrared fake 0]                                                  
+[infrared fake 0@Infrared_stage_party_data]                                                  
 Mode = 1                                                          
 Address = {hex @}                                        
 Fixcode={PATCH}  
@@ -688,27 +688,27 @@ Fixcode={PATCH}
 ;00029fc8h: 30 3E 3A 21 E9 4F CF CD 8C 61 CD C4 61 CD 0B 62 
 ;00029fd8h: F0 BE FE 10                                     
                                 
-[infrared fake 1@infrared_fake]                                                  
+[infrared fake 1@Infrared_ExchangeMysteryGiftData_function]                                                  
 Mode = 1                                                          
 Address = {hex @}                                      
 Fixcode={patch 0 21}      
 
-[infrared fake 2@infrared_fake]                    
+[infrared fake 2@Infrared_ExchangeMysteryGiftData_start]                    
 Mode = 2                             
 Address = {hex @}                    
 Type = 101    
 
-[infrared fake 5]          
+[infrared fake 5@Infrared_ExchangeMysteryGiftData_unknown_Mode100]          
 Mode = 2                   
 Address = {hex @}         
 Type = 100                                       
                                      
-[infrared fake 3]                    
+[infrared fake 3@Infrared_ExchangeMysteryGiftData_loop_done]                    
 Mode = 2                             
 Address = {hex @}                    
 Type = 102                           
                                      
-[infrared fake 4]                    
+[infrared fake 4@Infrared_ExchangeMysteryGiftData_end]                    
 Mode = 2                             
 Address = {hex @}                   
 Type = 103                           


### PR DESCRIPTION
Please reference: pret/pokecrystal#886 pret/pokecrystal#907

The only real difference here from pret/pokecrystal#907 is:

`infrared fake 5` => `Infrared_ExchangeMysteryGiftData_unknown_Mode100`  (This `mode = 100` does not exist in pokecrystal. Not sure what it does.)