### PR TITLE
Remove Heavy Ball never happens comment

### DIFF
--- a/engine/items/item_effects.asm
+++ b/engine/items/item_effects.asm
@@ -753,7 +753,7 @@ HeavyBallMultiplier:
 ; else add 0 to catch rate if weight < 204.8 kg
 ; else add 20 to catch rate if weight < 307.2 kg
 ; else add 30 to catch rate if weight < 409.6 kg
-; else add 40 to catch rate (never happens)
+; else add 40 to catch rate
 	ld a, [wEnemyMonSpecies]
 	dec a
 	ld hl, PokedexDataPointerTable


### PR DESCRIPTION
It's not correct as Snorlax weights more than 409.6 kg.

This is the same change as https://github.com/pret/pokecrystal/pull/925, except for pokegold.