### PR TITLE
Use the BG_MAP_WIDTH constant in the intro

### DIFF
--- a/engine/movie/intro.asm
+++ b/engine/movie/intro.asm
@@ -434,7 +434,7 @@ Intro_UpdateTilemapAndBGMap:
 	ld e, a
 	ld a, [wIntroTilemapPointer + 1]
 	ld d, a
-	ld hl, -$10
+	ld hl, -BG_MAP_WIDTH / 2
 	add hl, de
 	ld a, l
 	ld e, l
@@ -454,7 +454,7 @@ Intro_UpdateTilemapAndBGMap:
 	ld e, a
 	ld a, [wIntroBGMapPointer + 1]
 	ld d, a
-	ld hl, hCurSpriteYCoord
+	ld hl, -2 * BG_MAP_WIDTH
 	add hl, de
 	ld a, l
 	ld [wIntroBGMapPointer + 0], a


### PR DESCRIPTION
The intro movie adds the **values** from `wIntroBGMapPointer` to the **address** of `hCurSpriteYCoord`. If `hCurSpriteYCoord` is no longer located at `$ffc0` then Graphical glitches will occur during the intro movie when the movies begins to "rise towards the water surface". This PR is to add a an assert to warn the user that a graphical glitch may occur and where to fix the problem.