### PR TITLE
More accurate wLYOverrides Union

### DIFF
--- a/wram.asm
+++ b/wram.asm
@@ -651,6 +651,7 @@ wLYOverrides2End::
 
 NEXTU
 	ds 112
+
 	align 8
 wLYOverridesBackup:: ds SCREEN_HEIGHT_PX
 wLYOverridesBackupEnd::

--- a/wram.asm
+++ b/wram.asm
@@ -640,20 +640,24 @@ wMysteryGiftPlayerDataEnd::
 
 SECTION UNION "Overworld Map", WRAM0
 
-; LCD expects wLYOverrides to have an alignment of $100
+align 8
 wLYOverrides:: ds SCREEN_HEIGHT_PX
 wLYOverridesEnd::
 
 UNION
+align 8, SCREEN_HEIGHT_PX
 	ds 16
 wLYOverrides2:: ds SCREEN_HEIGHT_PX
 wLYOverrides2End::
 
 NEXTU
-	ds $100 - SCREEN_HEIGHT_PX
+	ds 112
+align 8
 wLYOverridesBackup:: ds SCREEN_HEIGHT_PX
-wLYOverridesBackupEnd:: ds $100 - SCREEN_HEIGHT_PX
+wLYOverridesBackupEnd::
 ENDU
+
+	ds 112
 
 UNION
 ; blank credits tile buffer

--- a/wram.asm
+++ b/wram.asm
@@ -640,19 +640,18 @@ wMysteryGiftPlayerDataEnd::
 
 SECTION UNION "Overworld Map", WRAM0
 
-align 8
+	align 8
 wLYOverrides:: ds SCREEN_HEIGHT_PX
 wLYOverridesEnd::
 
 UNION
-align 8, SCREEN_HEIGHT_PX
 	ds 16
 wLYOverrides2:: ds SCREEN_HEIGHT_PX
 wLYOverrides2End::
 
 NEXTU
 	ds 112
-align 8
+	align 8
 wLYOverridesBackup:: ds SCREEN_HEIGHT_PX
 wLYOverridesBackupEnd::
 ENDU


### PR DESCRIPTION
I noticed the Union for `wLYOverrides2` and `wLYOverridesBackup` are not defined very well. This pulls some extra bytes out of the union and provides a `SCREEN_HEIGHT_PX` overlap ratio (2/3rds).

Addr | Label
c700 - wLYOverrides
c790 - wLYOverridesEnd
c7a0 - wLYOverrides2
c800 - wLYOverridesBackup
c830 - wLYOverrides2End
c890 - wLYOverridesBackupEnd

As defined above, `wLYOverridesBackup` has about a 1/3rd overlap of `wLYOverrides2` starting about 2/3rds of the way through `wLYOverrides2`'s address space.