### PR TITLE
Document that `farcall` returns `c` in `a` for some code

### DIFF
--- a/engine/overworld/events.asm
+++ b/engine/overworld/events.asm
@@ -1073,9 +1073,13 @@ TryTileCollisionEvent::
 	call GetFacingTileCoord
 	ld [wFacingTileID], a
 	ld c, a
+	; CheckFacingTileForStdScript preserves c, and
+	; farcall copies c back into a.
 	farcall CheckFacingTileForStdScript
 	jr c, .done
 
+	; CheckCutTreeTile expects a == [wFacingTileID], which
+	; it still is after the previous farcall.
 	call CheckCutTreeTile
 	jr nz, .whirlpool
 	farcall TryCutOW


### PR DESCRIPTION
Please reference pret/pokecrystal#937