### PR TITLE
Add object priority mode constant and remove unnecessary constants

### DIFF
--- a/constants/hardware_constants.asm
+++ b/constants/hardware_constants.asm
@@ -155,12 +155,8 @@ DEF rBGPD                EQU $ff69 ; CGB Mode Only - Background Palette Data
 DEF rOBPI                EQU $ff6a ; CGB Mode Only - Sprite Palette Index
 DEF rOBPI_AUTO_INCREMENT EQU 7     ; increment rOBPI after write to rOBPD
 DEF rOBPD                EQU $ff6b ; CGB Mode Only - Sprite Palette Data
-DEF rUNKNOWN1            EQU $ff6c ; (FEh) Bit 0 (Read/Write) - CGB Mode Only
+DEF rOPRI                EQU $ff6c ; CGB Mode Only - Object Priority Mode
 DEF rSVBK                EQU $ff70 ; CGB Mode Only - WRAM Bank
-DEF rUNKNOWN2            EQU $ff72 ; (00h) - Bit 0-7 (Read/Write)
-DEF rUNKNOWN3            EQU $ff73 ; (00h) - Bit 0-7 (Read/Write)
-DEF rUNKNOWN4            EQU $ff74 ; (00h) - Bit 0-7 (Read/Write) - CGB Mode Only
-DEF rUNKNOWN5            EQU $ff75 ; (8Fh) - Bit 4-6 (Read/Write)
 DEF rPCM12               EQU $ff76 ; Channels 1 & 2 Amplitude (R)
 DEF rPCM34               EQU $ff77 ; Channels 3 & 4 Amplitude (R)
 DEF rIE                  EQU $ffff ; Interrupt Enable (R/W)


### PR DESCRIPTION
Mirrors pokecrystal's PR of the same nature (https://github.com/pret/pokecrystal/pull/972). See that PR for details.