### PR TITLE
Rename Scene & Callback Labels

### DIFF
--- a/maps/AzaleaPokecenter1F.asm
+++ b/maps/AzaleaPokecenter1F.asm
@@ -6,11 +6,11 @@
 
 AzaleaPokecenter1F_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene ; unusable
+	scene_script AzaleaPokecenter1FNoopScene ; unusable
 
 	def_callbacks
 
-.DummyScene:
+AzaleaPokecenter1FNoopScene:
 	end
 
 AzaleaPokecenter1FNurseScript:

--- a/maps/AzaleaTown.asm
+++ b/maps/AzaleaTown.asm
@@ -13,19 +13,19 @@
 
 AzaleaTown_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene0, SCENE_AZALEATOWN_NOOP
-	scene_script .DummyScene1, SCENE_AZALEATOWN_RIVAL_BATTLE
+	scene_script AzaleaTownNoop1Scene, SCENE_AZALEATOWN_NOOP
+	scene_script AzaleaTownNoop2Scene, SCENE_AZALEATOWN_RIVAL_BATTLE
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .Flypoint
+	callback MAPCALLBACK_NEWMAP, AzaleaTownFlypointCallback
 
-.DummyScene0:
+AzaleaTownNoop1Scene:
 	end
 
-.DummyScene1:
+AzaleaTownNoop2Scene:
 	end
 
-.Flypoint:
+AzaleaTownFlypointCallback:
 	setflag ENGINE_FLYPOINT_AZALEA
 	endcallback
 

--- a/maps/BlackthornCity.asm
+++ b/maps/BlackthornCity.asm
@@ -13,14 +13,14 @@ BlackthornCity_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .FlyPoint
-	callback MAPCALLBACK_OBJECTS, .Santos
+	callback MAPCALLBACK_NEWMAP, BlackthornCityFlypointCallback
+	callback MAPCALLBACK_OBJECTS, BlackthornCitySantosCallback
 
-.FlyPoint:
+BlackthornCityFlypointCallback:
 	setflag ENGINE_FLYPOINT_BLACKTHORN
 	endcallback
 
-.Santos:
+BlackthornCitySantosCallback:
 	readvar VAR_WEEKDAY
 	ifequal SATURDAY, .SantosAppears
 	disappear BLACKTHORNCITY_SANTOS

--- a/maps/BlackthornGym1F.asm
+++ b/maps/BlackthornGym1F.asm
@@ -9,9 +9,9 @@ BlackthornGym1F_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_TILES, .Boulders
+	callback MAPCALLBACK_TILES, BlackthornGym1FBouldersCallback
 
-.Boulders:
+BlackthornGym1FBouldersCallback:
 	checkevent EVENT_BOULDER_IN_BLACKTHORN_GYM_1
 	iffalse .skip1
 	changeblock 8, 2, $3b ; fallen boulder 2

--- a/maps/BlackthornGym2F.asm
+++ b/maps/BlackthornGym2F.asm
@@ -12,9 +12,9 @@ BlackthornGym2F_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_CMDQUEUE, .SetUpStoneTable
+	callback MAPCALLBACK_CMDQUEUE, BlackthornGym2FSetUpStoneTableCallback
 
-.SetUpStoneTable:
+BlackthornGym2FSetUpStoneTableCallback:
 	writecmdqueue .CommandQueue
 	endcallback
 

--- a/maps/BrunosRoom.asm
+++ b/maps/BrunosRoom.asm
@@ -3,20 +3,20 @@
 
 BrunosRoom_MapScripts:
 	def_scene_scripts
-	scene_script .LockDoor,   SCENE_BRUNOSROOM_LOCK_DOOR
-	scene_script .DummyScene, SCENE_BRUNOSROOM_NOOP
+	scene_script BrunosRoomLockDoorScene, SCENE_BRUNOSROOM_LOCK_DOOR
+	scene_script BrunosRoomNoopScene,     SCENE_BRUNOSROOM_NOOP
 
 	def_callbacks
-	callback MAPCALLBACK_TILES, .BrunosRoomDoors
+	callback MAPCALLBACK_TILES, BrunosRoomDoorsCallback
 
-.LockDoor:
-	sdefer .BrunosDoorLocksBehindYou
+BrunosRoomLockDoorScene:
+	sdefer BrunosRoomDoorLocksBehindYouScript
 	end
 
-.DummyScene:
+BrunosRoomNoopScene:
 	end
 
-.BrunosRoomDoors:
+BrunosRoomDoorsCallback:
 	checkevent EVENT_BRUNOS_ROOM_ENTRANCE_CLOSED
 	iffalse .KeepEntranceOpen
 	changeblock 4, 14, $2a ; wall
@@ -27,7 +27,7 @@ BrunosRoom_MapScripts:
 .KeepExitClosed:
 	endcallback
 
-.BrunosDoorLocksBehindYou:
+BrunosRoomDoorLocksBehindYouScript:
 	applymovement PLAYER, BrunosRoom_EnterMovement
 	refreshscreen $85
 	playsound SFX_STRENGTH

--- a/maps/BurnedTower1F.asm
+++ b/maps/BurnedTower1F.asm
@@ -10,23 +10,23 @@
 
 BurnedTower1F_MapScripts:
 	def_scene_scripts
-	scene_script .RivalScene,  SCENE_BURNEDTOWER1F_RIVAL_BATTLE
-	scene_script .DummyScene1, SCENE_BURNEDTOWER1F_FIREBREATHER_DICK
-	scene_script .DummyScene2, SCENE_BURNEDTOWER1F_NOOP
+	scene_script BurnedTower1FRivalBattleScene, SCENE_BURNEDTOWER1F_RIVAL_BATTLE
+	scene_script BurnedTower1FNoop1Scene,       SCENE_BURNEDTOWER1F_FIREBREATHER_DICK
+	scene_script BurnedTower1FNoop2Scene,       SCENE_BURNEDTOWER1F_NOOP
 
 	def_callbacks
 
-.RivalScene:
-	sdefer .Rival
+BurnedTower1FRivalBattleScene:
+	sdefer BurnedTower1FRivalBattleScript
 	end
 
-.DummyScene1:
+BurnedTower1FNoop1Scene:
 	end
 
-.DummyScene2:
+BurnedTower1FNoop2Scene:
 	end
 
-.Rival:
+BurnedTower1FRivalBattleScript:
 	turnobject PLAYER, UP
 	showemote EMOTE_SHOCK, PLAYER, 15
 	special FadeOutMusic

--- a/maps/BurnedTowerB1F.asm
+++ b/maps/BurnedTowerB1F.asm
@@ -11,15 +11,15 @@
 
 BurnedTowerB1F_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene0, SCENE_BURNEDTOWERB1F_RELEASE_THE_BEASTS
-	scene_script .DummyScene1, SCENE_BURNEDTOWERB1F_NOOP
+	scene_script BurnedTowerB1FNoop1Scene, SCENE_BURNEDTOWERB1F_RELEASE_THE_BEASTS
+	scene_script BurnedTowerB1FNoop2Scene, SCENE_BURNEDTOWERB1F_NOOP
 
 	def_callbacks
 
-.DummyScene0:
+BurnedTowerB1FNoop1Scene:
 	end
 
-.DummyScene1:
+BurnedTowerB1FNoop2Scene:
 	end
 
 ReleaseTheBeasts:

--- a/maps/CeladonCity.asm
+++ b/maps/CeladonCity.asm
@@ -13,9 +13,9 @@ CeladonCity_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .FlyPoint
+	callback MAPCALLBACK_NEWMAP, CeladonCityFlypointCallback
 
-.FlyPoint:
+CeladonCityFlypointCallback:
 	setflag ENGINE_FLYPOINT_CELADON
 	endcallback
 

--- a/maps/CeruleanCity.asm
+++ b/maps/CeruleanCity.asm
@@ -10,9 +10,9 @@ CeruleanCity_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .FlyPoint
+	callback MAPCALLBACK_NEWMAP, CeruleanCityFlypointCallback
 
-.FlyPoint:
+CeruleanCityFlypointCallback:
 	setflag ENGINE_FLYPOINT_CERULEAN
 	endcallback
 

--- a/maps/CeruleanGym.asm
+++ b/maps/CeruleanGym.asm
@@ -8,19 +8,19 @@
 
 CeruleanGym_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene0,  SCENE_CERULEANGYM_NOOP
-	scene_script .GruntRunsOut, SCENE_CERULEANGYM_GRUNT_RUNS_OUT
+	scene_script CeruleanGymNoopScene,         SCENE_CERULEANGYM_NOOP
+	scene_script CeruleanGymGruntRunsOutScene, SCENE_CERULEANGYM_GRUNT_RUNS_OUT
 
 	def_callbacks
 
-.DummyScene0:
+CeruleanGymNoopScene:
 	end
 
-.GruntRunsOut:
-	sdefer .GruntRunsOutScript
+CeruleanGymGruntRunsOutScene:
+	sdefer CeruleanGymGruntRunsOutScript
 	end
 
-.GruntRunsOutScript:
+CeruleanGymGruntRunsOutScript:
 	applymovement CERULEANGYM_ROCKET, CeruleanGymGruntRunsDownMovement
 	playsound SFX_TACKLE
 	applymovement CERULEANGYM_ROCKET, CeruleanGymGruntRunsIntoYouMovement

--- a/maps/CherrygroveCity.asm
+++ b/maps/CherrygroveCity.asm
@@ -7,19 +7,19 @@
 
 CherrygroveCity_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene0, SCENE_CHERRYGROVECITY_NOOP
-	scene_script .DummyScene1, SCENE_CHERRYGROVECITY_MEET_RIVAL
+	scene_script CherrygroveCityNoop1Scene, SCENE_CHERRYGROVECITY_NOOP
+	scene_script CherrygroveCityNoop2Scene, SCENE_CHERRYGROVECITY_MEET_RIVAL
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .FlyPoint
+	callback MAPCALLBACK_NEWMAP, CherrygroveCityFlypointCallback
 
-.DummyScene0:
+CherrygroveCityNoop1Scene:
 	end
 
-.DummyScene1:
+CherrygroveCityNoop2Scene:
 	end
 
-.FlyPoint:
+CherrygroveCityFlypointCallback:
 	setflag ENGINE_FLYPOINT_CHERRYGROVE
 	endcallback
 

--- a/maps/CianwoodCity.asm
+++ b/maps/CianwoodCity.asm
@@ -14,9 +14,9 @@ CianwoodCity_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .FlyPoint
+	callback MAPCALLBACK_NEWMAP, CianwoodCityFlypointCallback
 
-.FlyPoint:
+CianwoodCityFlypointCallback:
 	setflag ENGINE_FLYPOINT_CIANWOOD
 	endcallback
 

--- a/maps/CianwoodPharmacy.asm
+++ b/maps/CianwoodPharmacy.asm
@@ -3,11 +3,11 @@
 
 CianwoodPharmacy_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene
+	scene_script CianwoodPharmacyNoopScene ; unusable
 
 	def_callbacks
 
-.DummyScene:
+CianwoodPharmacyNoopScene:
 	end
 
 CianwoodPharmacist:

--- a/maps/CinnabarIsland.asm
+++ b/maps/CinnabarIsland.asm
@@ -5,9 +5,9 @@ CinnabarIsland_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .FlyPoint
+	callback MAPCALLBACK_NEWMAP, CinnabarIslandFlypointCallback
 
-.FlyPoint:
+CinnabarIslandFlypointCallback:
 	setflag ENGINE_FLYPOINT_CINNABAR
 	endcallback
 

--- a/maps/Colosseum.asm
+++ b/maps/Colosseum.asm
@@ -4,20 +4,20 @@
 
 Colosseum_MapScripts:
 	def_scene_scripts
-	scene_script .InitializeColosseum, SCENE_COLOSSEUM_INITIALIZE
-	scene_script .DummyScene1,         SCENE_COLOSSEUM_NOOP
+	scene_script ColosseumInitializeScene, SCENE_COLOSSEUM_INITIALIZE
+	scene_script ColosseumNoop1Scene,      SCENE_COLOSSEUM_NOOP
 
 	def_callbacks
-	callback MAPCALLBACK_OBJECTS, .SetWhichChris
+	callback MAPCALLBACK_OBJECTS, ColosseumSetWhichChrisCallback
 
-.InitializeColosseum:
-	sdefer .InitializeAndPreparePokecenter2F
+ColosseumInitializeScene:
+	sdefer ColosseumInitializeAndPreparePokecenter2FScript
 	end
 
-.DummyScene1:
+ColosseumNoop1Scene:
 	end
 
-.SetWhichChris:
+ColosseumSetWhichChrisCallback:
 	special CableClubCheckWhichChris
 	iffalse .Chris2
 	disappear COLOSSEUM_CHRIS2
@@ -29,7 +29,7 @@ Colosseum_MapScripts:
 	appear COLOSSEUM_CHRIS2
 	endcallback
 
-.InitializeAndPreparePokecenter2F:
+ColosseumInitializeAndPreparePokecenter2FScript:
 	setscene SCENE_COLOSSEUM_NOOP
 	setmapscene POKECENTER_2F, SCENE_POKECENTER2F_LEAVE_COLOSSEUM
 	end

--- a/maps/DayCare.asm
+++ b/maps/DayCare.asm
@@ -6,9 +6,9 @@ DayCare_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_OBJECTS, .EggCheckCallback
+	callback MAPCALLBACK_OBJECTS, DayCareEggCheckCallback
 
-.EggCheckCallback:
+DayCareEggCheckCallback:
 	checkflag ENGINE_DAY_CARE_MAN_HAS_EGG
 	iftrue .PutDayCareManOutside
 	clearevent EVENT_DAY_CARE_MAN_IN_DAY_CARE

--- a/maps/DragonsDenB1F.asm
+++ b/maps/DragonsDenB1F.asm
@@ -7,9 +7,9 @@ DragonsDenB1F_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .CheckSilver
+	callback MAPCALLBACK_NEWMAP, DragonsDenB1FCheckSilverCallback
 
-.CheckSilver:
+DragonsDenB1FCheckSilverCallback:
 	checkevent EVENT_BEAT_RIVAL_IN_MT_MOON
 	iftrue .CheckDay
 	disappear DRAGONSDENB1F_SILVER

--- a/maps/EcruteakCity.asm
+++ b/maps/EcruteakCity.asm
@@ -10,9 +10,9 @@ EcruteakCity_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .FlyPoint
+	callback MAPCALLBACK_NEWMAP, EcruteakCityFlypointCallback
 
-.FlyPoint:
+EcruteakCityFlypointCallback:
 	setflag ENGINE_FLYPOINT_ECRUTEAK
 	endcallback
 

--- a/maps/EcruteakPokecenter1F.asm
+++ b/maps/EcruteakPokecenter1F.asm
@@ -7,19 +7,19 @@
 
 EcruteakPokecenter1F_MapScripts:
 	def_scene_scripts
-	scene_script .MeetBill,   SCENE_ECRUTEAKPOKECENTER1F_MEET_BILL
-	scene_script .DummyScene, SCENE_ECRUTEAKPOKECENTER1F_NOOP
+	scene_script EcruteakPokecenter1FMeetBillScene, SCENE_ECRUTEAKPOKECENTER1F_MEET_BILL
+	scene_script EcruteakPokecenter1FNoopScene,     SCENE_ECRUTEAKPOKECENTER1F_NOOP
 
 	def_callbacks
 
-.MeetBill:
-	sdefer .BillActivatesTimeCapsule
+EcruteakPokecenter1FMeetBillScene:
+	sdefer EcruteakPokcenter1FBillActivatesTimeCapsuleScript
 	end
 
-.DummyScene:
+EcruteakPokecenter1FNoopScene:
 	end
 
-.BillActivatesTimeCapsule:
+EcruteakPokcenter1FBillActivatesTimeCapsuleScript:
 	pause 30
 	playsound SFX_EXIT_BUILDING
 	appear ECRUTEAKPOKECENTER1F_BILL

--- a/maps/EcruteakTinTowerEntrance.asm
+++ b/maps/EcruteakTinTowerEntrance.asm
@@ -6,15 +6,15 @@
 
 EcruteakTinTowerEntrance_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene0, SCENE_ECRUTEAKTINTOWERENTRANCE_SAGE_BLOCKS
-	scene_script .DummyScene1, SCENE_ECRUTEAKTINTOWERENTRANCE_NOOP
+	scene_script EcruteakTinTowerEntranceNoop1Scene, SCENE_ECRUTEAKTINTOWERENTRANCE_SAGE_BLOCKS
+	scene_script EcruteakTinTowerEntranceNoop2Scene, SCENE_ECRUTEAKTINTOWERENTRANCE_NOOP
 
 	def_callbacks
 
-.DummyScene0:
+EcruteakTinTowerEntranceNoop1Scene:
 	end
 
-.DummyScene1:
+EcruteakTinTowerEntranceNoop2Scene:
 	end
 
 EcruteakTinTowerEntranceSageBlocksLeft:

--- a/maps/ElmsLab.asm
+++ b/maps/ElmsLab.asm
@@ -8,36 +8,36 @@
 
 ElmsLab_MapScripts:
 	def_scene_scripts
-	scene_script .MeetElm,     SCENE_ELMSLAB_MEET_ELM
-	scene_script .DummyScene1, SCENE_ELMSLAB_CANT_LEAVE
-	scene_script .DummyScene2, SCENE_ELMSLAB_NOOP
-	scene_script .DummyScene3, SCENE_ELMSLAB_MEET_OFFICER
-	scene_script .DummyScene4, SCENE_ELMSLAB_UNUSED
-	scene_script .DummyScene5, SCENE_ELMSLAB_AIDE_GIVES_POTION
+	scene_script ElmsLabMeetElmScene, SCENE_ELMSLAB_MEET_ELM
+	scene_script ElmsLabNoop1Scene,   SCENE_ELMSLAB_CANT_LEAVE
+	scene_script ElmsLabNoop2Scene,   SCENE_ELMSLAB_NOOP
+	scene_script ElmsLabNoop3Scene,   SCENE_ELMSLAB_MEET_OFFICER
+	scene_script ElmsLabNoop4Scene,   SCENE_ELMSLAB_UNUSED
+	scene_script ElmsLabNoop5Scene,   SCENE_ELMSLAB_AIDE_GIVES_POTION
 	scene_const SCENE_ELMSLAB_AIDE_GIVES_POKE_BALLS
 
 	def_callbacks
 
-.MeetElm:
-	sdefer .WalkUpToElm
+ElmsLabMeetElmScene:
+	sdefer ElmsLabWalkUpToElmScript
 	end
 
-.DummyScene1:
+ElmsLabNoop1Scene:
 	end
 
-.DummyScene2:
+ElmsLabNoop2Scene:
 	end
 
-.DummyScene3:
+ElmsLabNoop3Scene:
 	end
 
-.DummyScene4:
+ElmsLabNoop4Scene:
 	end
 
-.DummyScene5:
+ElmsLabNoop5Scene:
 	end
 
-.WalkUpToElm:
+ElmsLabWalkUpToElmScript:
 	applymovement PLAYER, ElmsLab_WalkUpToElmMovement
 	turnobject ELMSLAB_ELM, LEFT
 	opentext

--- a/maps/FastShip1F.asm
+++ b/maps/FastShip1F.asm
@@ -6,23 +6,23 @@
 
 FastShip1F_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene0,   SCENE_FASTSHIP1F_NOOP
-	scene_script .EnterFastShip, SCENE_FASTSHIP1F_ENTER_SHIP
-	scene_script .DummyScene2,   SCENE_FASTSHIP1F_MEET_GRANDPA
+	scene_script FastShip1FNoop1Scene,     SCENE_FASTSHIP1F_NOOP
+	scene_script FastShip1FEnterShipScene, SCENE_FASTSHIP1F_ENTER_SHIP
+	scene_script FastShip1FNoop2Scene,     SCENE_FASTSHIP1F_MEET_GRANDPA
 
 	def_callbacks
 
-.DummyScene0:
+FastShip1FNoop1Scene:
 	end
 
-.EnterFastShip:
-	sdefer .EnterFastShipScript
+FastShip1FEnterShipScene:
+	sdefer FastShip1FEnterShipScript
 	end
 
-.DummyScene2:
+FastShip1FNoop2Scene:
 	end
 
-.EnterFastShipScript:
+FastShip1FEnterShipScript:
 	applymovement FASTSHIP1F_SAILOR1, FastShip1F_SailorStepAsideMovement
 	applymovement PLAYER, FastShip1F_PlayerEntersShipMovement
 	applymovement FASTSHIP1F_SAILOR1, FastShip1F_SailorBlocksDoorMovement

--- a/maps/FastShipB1F.asm
+++ b/maps/FastShipB1F.asm
@@ -14,15 +14,15 @@
 
 FastShipB1F_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene0, SCENE_FASTSHIPB1F_SAILOR_BLOCKS
-	scene_script .DummyScene1, SCENE_FASTSHIPB1F_NOOP
+	scene_script FastShipB1FNoop1Scene, SCENE_FASTSHIPB1F_SAILOR_BLOCKS
+	scene_script FastShipB1FNoop2Scene, SCENE_FASTSHIPB1F_NOOP
 
 	def_callbacks
 
-.DummyScene0:
+FastShipB1FNoop1Scene:
 	end
 
-.DummyScene1:
+FastShipB1FNoop2Scene:
 	end
 
 FastShipB1FSailorBlocksLeft:

--- a/maps/FastShipCabins_SE_SSE_CaptainsCabin.asm
+++ b/maps/FastShipCabins_SE_SSE_CaptainsCabin.asm
@@ -16,7 +16,7 @@ FastShipCabins_SE_SSE_CaptainsCabin_MapScripts:
 
 	def_callbacks
 
-.DummyScene: ; unreferenced
+FastShipCabins_SE_SSE_CaptainsCabinNoopScene: ; unreferenced
 	end
 
 SSAquaCaptain:

--- a/maps/FuchsiaCity.asm
+++ b/maps/FuchsiaCity.asm
@@ -8,9 +8,9 @@ FuchsiaCity_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .FlyPoint
+	callback MAPCALLBACK_NEWMAP, FuchsiaCityFlypointCallback
 
-.FlyPoint:
+FuchsiaCityFlypointCallback:
 	setflag ENGINE_FLYPOINT_FUCHSIA
 	endcallback
 

--- a/maps/FuchsiaPokecenter1F.asm
+++ b/maps/FuchsiaPokecenter1F.asm
@@ -6,11 +6,11 @@
 
 FuchsiaPokecenter1F_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene ; unusable
+	scene_script FuchsiaPokeCenter1FNoopScene ; unusable
 
 	def_callbacks
 
-.DummyScene:
+FuchsiaPokeCenter1FNoopScene:
 	end
 
 FuchsiaPokecenter1FNurseScript:

--- a/maps/GoldenrodBikeShop.asm
+++ b/maps/GoldenrodBikeShop.asm
@@ -6,7 +6,7 @@ GoldenrodBikeShop_MapScripts:
 
 	def_callbacks
 
-.DummyScene: ; unreferenced
+GoldenrodBikeShopNoopScene: ; unreferenced
 	end
 
 GoldenrodBikeShopClerkScript:

--- a/maps/GoldenrodCity.asm
+++ b/maps/GoldenrodCity.asm
@@ -18,9 +18,9 @@ GoldenrodCity_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .FlyPoint
+	callback MAPCALLBACK_NEWMAP, GoldenrodCityFlypointCallback
 
-.FlyPoint:
+GoldenrodCityFlypointCallback:
 	setflag ENGINE_FLYPOINT_GOLDENROD
 	setflag ENGINE_REACHED_GOLDENROD
 	endcallback

--- a/maps/GoldenrodDeptStore5F.asm
+++ b/maps/GoldenrodDeptStore5F.asm
@@ -10,9 +10,9 @@ GoldenrodDeptStore5F_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_OBJECTS, .CheckIfSunday
+	callback MAPCALLBACK_OBJECTS, GoldenrodDeptStore5FCheckIfSundayCallback
 
-.CheckIfSunday:
+GoldenrodDeptStore5FCheckIfSundayCallback:
 	readvar VAR_WEEKDAY
 	ifequal SUNDAY, .yes
 	disappear GOLDENRODDEPTSTORE5F_RECEPTIONIST

--- a/maps/GoldenrodDeptStoreB1F.asm
+++ b/maps/GoldenrodDeptStoreB1F.asm
@@ -12,10 +12,10 @@ GoldenrodDeptStoreB1F_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_TILES, .ClearBoxes
-	callback MAPCALLBACK_NEWMAP, .Unblock
+	callback MAPCALLBACK_TILES, GoldenRodDeptStoreB1FClearBoxesCallback
+	callback MAPCALLBACK_NEWMAP, GoldenRodDeptStoreUnblockCallback
 
-.ClearBoxes:
+GoldenRodDeptStoreB1FClearBoxesCallback:
 	checkevent EVENT_RECEIVED_CARD_KEY
 	iftrue .GotCardKey
 	sjump .Continue
@@ -40,7 +40,7 @@ GoldenrodDeptStoreB1F_MapScripts:
 	changeblock 10, 12, $0d ; floor
 	endcallback
 
-.Unblock:
+GoldenRodDeptStoreUnblockCallback:
 	clearevent EVENT_GOLDENROD_UNDERGROUND_WAREHOUSE_BLOCKED_OFF
 	endcallback
 

--- a/maps/GoldenrodGym.asm
+++ b/maps/GoldenrodGym.asm
@@ -8,15 +8,15 @@
 
 GoldenrodGym_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene0, SCENE_GOLDENRODGYM_NOOP
-	scene_script .DummyScene1, SCENE_GOLDENRODGYM_WHITNEY_STOPS_CRYING
+	scene_script GoldenrodGymNoop1Scene, SCENE_GOLDENRODGYM_NOOP
+	scene_script GoldenrodGymNoop2Scene, SCENE_GOLDENRODGYM_WHITNEY_STOPS_CRYING
 
 	def_callbacks
 
-.DummyScene0:
+GoldenrodGymNoop1Scene:
 	end
 
-.DummyScene1:
+GoldenrodGymNoop2Scene:
 	end
 
 GoldenrodGymWhitneyScript:

--- a/maps/GoldenrodMagnetTrainStation.asm
+++ b/maps/GoldenrodMagnetTrainStation.asm
@@ -4,11 +4,11 @@
 
 GoldenrodMagnetTrainStation_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene, SCENE_GOLDENRODMAGNETTRAINSTATION_ARRIVE_FROM_SAFFRON
+	scene_script GoldenrodMagnetTrainStationNoopScene, SCENE_GOLDENRODMAGNETTRAINSTATION_ARRIVE_FROM_SAFFRON
 
 	def_callbacks
 
-.DummyScene:
+GoldenrodMagnetTrainStationNoopScene:
 	end
 
 GoldenrodMagnetTrainStationOfficerScript:

--- a/maps/GoldenrodUnderground.asm
+++ b/maps/GoldenrodUnderground.asm
@@ -16,11 +16,11 @@ GoldenrodUnderground_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .ResetSwitches
-	callback MAPCALLBACK_TILES, .CheckBasementKey
-	callback MAPCALLBACK_OBJECTS, .CheckDayOfWeek
+	callback MAPCALLBACK_NEWMAP, GoldenrodUndergroundResetSwitchesCallback
+	callback MAPCALLBACK_TILES, GoldenrodUndergroundCheckBasementKeyCallback
+	callback MAPCALLBACK_OBJECTS, GoldenrodUndergroundCheckDayOfWeekCallback
 
-.ResetSwitches:
+GoldenrodUndergroundResetSwitchesCallback:
 	clearevent EVENT_SWITCH_1
 	clearevent EVENT_SWITCH_2
 	clearevent EVENT_SWITCH_3
@@ -40,7 +40,7 @@ GoldenrodUnderground_MapScripts:
 	writemem wUndergroundSwitchPositions
 	endcallback
 
-.CheckBasementKey:
+GoldenrodUndergroundCheckBasementKeyCallback:
 	checkevent EVENT_USED_BASEMENT_KEY
 	iffalse .LockBasementDoor
 	endcallback
@@ -49,7 +49,7 @@ GoldenrodUnderground_MapScripts:
 	changeblock 18, 6, $3d ; locked door
 	endcallback
 
-.CheckDayOfWeek:
+GoldenrodUndergroundCheckDayOfWeekCallback:
 	readvar VAR_WEEKDAY
 	ifequal MONDAY, .Monday
 	ifequal TUESDAY, .Tuesday

--- a/maps/GoldenrodUndergroundSwitchRoomEntrances.asm
+++ b/maps/GoldenrodUndergroundSwitchRoomEntrances.asm
@@ -47,19 +47,19 @@ ENDM
 
 GoldenrodUndergroundSwitchRoomEntrances_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene0, SCENE_GOLDENRODUNDERGROUNDSWITCHROOMENTRANCES_RIVAL_BATTLE
-	scene_script .DummyScene1, SCENE_GOLDENRODUNDERGROUNDSWITCHROOMENTRANCES_NOOP
+	scene_script GoldenrodUndergroundSwitchRoomEntrancesNoop1Scene, SCENE_GOLDENRODUNDERGROUNDSWITCHROOMENTRANCES_RIVAL_BATTLE
+	scene_script GoldenrodUndergroundSwitchRoomEntrancesNoop2Scene, SCENE_GOLDENRODUNDERGROUNDSWITCHROOMENTRANCES_NOOP
 
 	def_callbacks
-	callback MAPCALLBACK_TILES, .UpdateDoorPositions
+	callback MAPCALLBACK_TILES, GoldenrodUndergroundSwitchRoomEntrancesUpdateDoorPositionsCallback
 
-.DummyScene0:
+GoldenrodUndergroundSwitchRoomEntrancesNoop1Scene:
 	end
 
-.DummyScene1:
+GoldenrodUndergroundSwitchRoomEntrancesNoop2Scene:
 	end
 
-.UpdateDoorPositions:
+GoldenrodUndergroundSwitchRoomEntrancesUpdateDoorPositionsCallback:
 	checkevent EVENT_SWITCH_4
 	iffalse .false4
 	doorstate 1, OPEN1

--- a/maps/GoldenrodUndergroundWarehouse.asm
+++ b/maps/GoldenrodUndergroundWarehouse.asm
@@ -10,9 +10,9 @@ GoldenrodUndergroundWarehouse_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .ResetSwitches
+	callback MAPCALLBACK_NEWMAP, GoldenrodUndergroundWarehouseResetSwitchesCallback
 
-.ResetSwitches:
+GoldenrodUndergroundWarehouseResetSwitchesCallback:
 	clearevent EVENT_SWITCH_1
 	clearevent EVENT_SWITCH_2
 	clearevent EVENT_SWITCH_3

--- a/maps/HallOfFame.asm
+++ b/maps/HallOfFame.asm
@@ -3,19 +3,19 @@
 
 HallOfFame_MapScripts:
 	def_scene_scripts
-	scene_script .EnterHallOfFame, SCENE_HALLOFFAME_ENTER
-	scene_script .DummyScene,      SCENE_HALLOFFAME_NOOP
+	scene_script HallOfFameEnterScene, SCENE_HALLOFFAME_ENTER
+	scene_script HallOfFameNoopScene,  SCENE_HALLOFFAME_NOOP
 
 	def_callbacks
 
-.EnterHallOfFame:
-	sdefer .EnterHallOfFameScript
+HallOfFameEnterScene:
+	sdefer HallOfFameEnterScript
 	end
 
-.DummyScene:
+HallOfFameNoopScene:
 	end
 
-.EnterHallOfFameScript:
+HallOfFameEnterScript:
 	follow HALLOFFAME_LANCE, PLAYER
 	applymovement HALLOFFAME_LANCE, HallOfFame_WalkUpWithLance
 	stopfollow

--- a/maps/IcePathB1F.asm
+++ b/maps/IcePathB1F.asm
@@ -9,9 +9,9 @@ IcePathB1F_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_CMDQUEUE, .SetUpStoneTable
+	callback MAPCALLBACK_CMDQUEUE, IcePathB1FSetUpStoneTableCallback
 
-.SetUpStoneTable:
+IcePathB1FSetUpStoneTableCallback:
 	writecmdqueue .CommandQueue
 	endcallback
 

--- a/maps/IndigoPlateauPokecenter1F.asm
+++ b/maps/IndigoPlateauPokecenter1F.asm
@@ -8,15 +8,15 @@
 
 IndigoPlateauPokecenter1F_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene, SCENE_INDIGOPLATEAUPOKECENTER1F_RIVAL_BATTLE
+	scene_script IndigoPlateauPokecenter1FNoopScene, SCENE_INDIGOPLATEAUPOKECENTER1F_RIVAL_BATTLE
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .PrepareElite4
+	callback MAPCALLBACK_NEWMAP, IndigoPlateauPokecenter1FPrepareElite4Callback
 
-.DummyScene:
+IndigoPlateauPokecenter1FNoopScene:
 	end
 
-.PrepareElite4:
+IndigoPlateauPokecenter1FPrepareElite4Callback:
 	setmapscene WILLS_ROOM, SCENE_WILLSROOM_LOCK_DOOR
 	setmapscene KOGAS_ROOM, SCENE_KOGASROOM_LOCK_DOOR
 	setmapscene BRUNOS_ROOM, SCENE_BRUNOSROOM_LOCK_DOOR

--- a/maps/KarensRoom.asm
+++ b/maps/KarensRoom.asm
@@ -3,20 +3,20 @@
 
 KarensRoom_MapScripts:
 	def_scene_scripts
-	scene_script .LockDoor,   SCENE_KARENSROOM_LOCK_DOOR
-	scene_script .DummyScene, SCENE_KARENSROOM_NOOP
+	scene_script KarensRoomLockDoorScene, SCENE_KARENSROOM_LOCK_DOOR
+	scene_script KarensRoomNoopScene,     SCENE_KARENSROOM_NOOP
 
 	def_callbacks
-	callback MAPCALLBACK_TILES, .KarensRoomDoors
+	callback MAPCALLBACK_TILES, KarensRoomDoorsCallback
 
-.LockDoor:
-	sdefer .KarensDoorLocksBehindYou
+KarensRoomLockDoorScene:
+	sdefer KarensRoomDoorLocksBehindYouScript
 	end
 
-.DummyScene:
+KarensRoomNoopScene:
 	end
 
-.KarensRoomDoors:
+KarensRoomDoorsCallback:
 	checkevent EVENT_KARENS_ROOM_ENTRANCE_CLOSED
 	iffalse .KeepEntranceOpen
 	changeblock 4, 14, $2a ; wall
@@ -27,7 +27,7 @@ KarensRoom_MapScripts:
 .KeepExitClosed:
 	endcallback
 
-.KarensDoorLocksBehindYou:
+KarensRoomDoorLocksBehindYouScript:
 	applymovement PLAYER, KarensRoom_EnterMovement
 	refreshscreen $85
 	playsound SFX_STRENGTH

--- a/maps/KogasRoom.asm
+++ b/maps/KogasRoom.asm
@@ -3,20 +3,20 @@
 
 KogasRoom_MapScripts:
 	def_scene_scripts
-	scene_script .LockDoor,   SCENE_KOGASROOM_LOCK_DOOR
-	scene_script .DummyScene, SCENE_KOGASROOM_NOOP
+	scene_script KogasRoomLockDoorScene, SCENE_KOGASROOM_LOCK_DOOR
+	scene_script KogasRoomNoopScene,     SCENE_KOGASROOM_NOOP
 
 	def_callbacks
-	callback MAPCALLBACK_TILES, .KogasRoomDoors
+	callback MAPCALLBACK_TILES, KogasRoomDoorsCallback
 
-.LockDoor:
-	sdefer .KogasDoorLocksBehindYou
+KogasRoomLockDoorScene:
+	sdefer KogasRoomDoorLocksBehindYouScript
 	end
 
-.DummyScene:
+KogasRoomNoopScene:
 	end
 
-.KogasRoomDoors:
+KogasRoomDoorsCallback:
 	checkevent EVENT_KOGAS_ROOM_ENTRANCE_CLOSED
 	iffalse .KeepEntranceOpen
 	changeblock 4, 14, $2a ; wall
@@ -27,7 +27,7 @@ KogasRoom_MapScripts:
 .KeepExitClosed:
 	endcallback
 
-.KogasDoorLocksBehindYou:
+KogasRoomDoorLocksBehindYouScript:
 	applymovement PLAYER, KogasRoom_EnterMovement
 	refreshscreen $85
 	playsound SFX_STRENGTH

--- a/maps/KurtsHouse.asm
+++ b/maps/KurtsHouse.asm
@@ -8,9 +8,9 @@ KurtsHouse_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_OBJECTS, .KurtCallback
+	callback MAPCALLBACK_OBJECTS, KurtsHouseKurtCallback
 
-.KurtCallback:
+KurtsHouseKurtCallback:
 	checkevent EVENT_CLEARED_SLOWPOKE_WELL
 	iffalse .Done
 	checkflag ENGINE_KURT_MAKING_BALLS

--- a/maps/LakeOfRage.asm
+++ b/maps/LakeOfRage.asm
@@ -14,24 +14,24 @@
 
 LakeOfRage_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene0 ; unusable
-	scene_script .DummyScene1 ; unusable
+	scene_script LakeOfRageNoop1Scene ; unusable
+	scene_script LakeOfRageNoop2Scene ; unusable
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .FlyPoint
-	callback MAPCALLBACK_OBJECTS, .Wesley
+	callback MAPCALLBACK_NEWMAP, LakeOfRageFlypointCallback
+	callback MAPCALLBACK_OBJECTS, LakeOfRageWesleyCallback
 
-.DummyScene0:
+LakeOfRageNoop1Scene:
 	end
 
-.DummyScene1:
+LakeOfRageNoop2Scene:
 	end
 
-.FlyPoint:
+LakeOfRageFlypointCallback:
 	setflag ENGINE_FLYPOINT_LAKE_OF_RAGE
 	endcallback
 
-.Wesley:
+LakeOfRageWesleyCallback:
 	readvar VAR_WEEKDAY
 	ifequal WEDNESDAY, .WesleyAppears
 	disappear LAKEOFRAGE_WESLEY

--- a/maps/LancesRoom.asm
+++ b/maps/LancesRoom.asm
@@ -5,20 +5,20 @@
 
 LancesRoom_MapScripts:
 	def_scene_scripts
-	scene_script .LockDoor,   SCENE_LANCESROOM_LOCK_DOOR
-	scene_script .DummyScene, SCENE_LANCESROOM_APPROACH_LANCE
+	scene_script LancesRoomLockDoorScene, SCENE_LANCESROOM_LOCK_DOOR
+	scene_script LancesRoomNoopScene,     SCENE_LANCESROOM_APPROACH_LANCE
 
 	def_callbacks
-	callback MAPCALLBACK_TILES, .LancesRoomDoors
+	callback MAPCALLBACK_TILES, LancesRoomDoorsCallback
 
-.LockDoor:
-	sdefer .LancesDoorLocksBehindYou
+LancesRoomLockDoorScene:
+	sdefer LancesRoomDoorLocksBehindYouScript
 	end
 
-.DummyScene:
+LancesRoomNoopScene:
 	end
 
-.LancesRoomDoors:
+LancesRoomDoorsCallback:
 	checkevent EVENT_LANCES_ROOM_ENTRANCE_CLOSED
 	iffalse .KeepEntranceOpen
 	changeblock 4, 22, $34 ; wall
@@ -29,7 +29,7 @@ LancesRoom_MapScripts:
 .KeepExitClosed:
 	endcallback
 
-.LancesDoorLocksBehindYou:
+LancesRoomDoorLocksBehindYouScript:
 	applymovement PLAYER, LancesRoom_EnterMovement
 	refreshscreen $85
 	playsound SFX_STRENGTH

--- a/maps/LavenderNameRater.asm
+++ b/maps/LavenderNameRater.asm
@@ -3,11 +3,11 @@
 
 LavenderNameRater_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene ; unusable
+	scene_script LavenderNameRaterNoopScene ; unusable
 
 	def_callbacks
 
-.DummyScene:
+LavenderNameRaterNoopScene:
 	end
 
 LavenderNameRater:

--- a/maps/LavenderTown.asm
+++ b/maps/LavenderTown.asm
@@ -8,9 +8,9 @@ LavenderTown_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .FlyPoint
+	callback MAPCALLBACK_NEWMAP, LavenderTownFlypointCallback
 
-.FlyPoint:
+LavenderTownFlypointCallback:
 	setflag ENGINE_FLYPOINT_LAVENDER
 	endcallback
 

--- a/maps/MahoganyMart1F.asm
+++ b/maps/MahoganyMart1F.asm
@@ -7,20 +7,20 @@
 
 MahoganyMart1F_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene0,            SCENE_MAHOGANYMART1F_NOOP
-	scene_script .LanceUncoversStaircase, SCENE_MAHOGANYMART1F_LANCE_UNCOVERS_STAIRS
+	scene_script MahoganyMart1FNoopScene,                SCENE_MAHOGANYMART1F_NOOP
+	scene_script MahoganyMart1FLanceUncoversStairsScene, SCENE_MAHOGANYMART1F_LANCE_UNCOVERS_STAIRS
 
 	def_callbacks
-	callback MAPCALLBACK_TILES, .MahoganyMart1FStaircase
+	callback MAPCALLBACK_TILES, MahoganyMart1FStaircaseCallback
 
-.DummyScene0:
+MahoganyMart1FNoopScene:
 	end
 
-.LanceUncoversStaircase:
+MahoganyMart1FLanceUncoversStairsScene:
 	sdefer MahoganyMart1FLanceUncoversStaircaseScript
 	end
 
-.MahoganyMart1FStaircase:
+MahoganyMart1FStaircaseCallback:
 	checkevent EVENT_UNCOVERED_STAIRCASE_IN_MAHOGANY_MART
 	iftrue .ShowStairs
 	endcallback

--- a/maps/MahoganyTown.asm
+++ b/maps/MahoganyTown.asm
@@ -8,19 +8,19 @@ DEF MAHOGANYTOWN_RAGECANDYBAR_PRICE EQU 300
 
 MahoganyTown_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene0, SCENE_MAHOGANYTOWN_TRY_RAGECANDYBAR
-	scene_script .DummyScene1, SCENE_MAHOGANYTOWN_NOOP
+	scene_script MahoganyTownNoop1Scene, SCENE_MAHOGANYTOWN_TRY_RAGECANDYBAR
+	scene_script MahoganyTownNoop2Scene, SCENE_MAHOGANYTOWN_NOOP
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .FlyPoint
+	callback MAPCALLBACK_NEWMAP, MahoganyTownFlypointCallback
 
-.DummyScene0:
+MahoganyTownNoop1Scene:
 	end
 
-.DummyScene1:
+MahoganyTownNoop2Scene:
 	end
 
-.FlyPoint:
+MahoganyTownFlypointCallback:
 	setflag ENGINE_FLYPOINT_MAHOGANY
 	endcallback
 

--- a/maps/MountMoon.asm
+++ b/maps/MountMoon.asm
@@ -3,19 +3,19 @@
 
 MountMoon_MapScripts:
 	def_scene_scripts
-	scene_script .RivalEncounter, SCENE_MOUNTMOON_RIVAL_BATTLE
-	scene_script .DummyScene,     SCENE_MOUNTMOON_NOOP
+	scene_script MountMoonRivalEncounterScene, SCENE_MOUNTMOON_RIVAL_BATTLE
+	scene_script MountMoonNoopScene,           SCENE_MOUNTMOON_NOOP
 
 	def_callbacks
 
-.RivalEncounter:
-	sdefer .RivalBattle
+MountMoonRivalEncounterScene:
+	sdefer MountMoonRivalBattleScript
 	end
 
-.DummyScene:
+MountMoonNoopScene:
 	end
 
-.RivalBattle:
+MountMoonRivalBattleScript:
 	turnobject PLAYER, RIGHT
 	showemote EMOTE_SHOCK, PLAYER, 15
 	special FadeOutMusic

--- a/maps/MountMoonSquare.asm
+++ b/maps/MountMoonSquare.asm
@@ -5,20 +5,20 @@
 
 MountMoonSquare_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene, SCENE_MOUNTMOONSQUARE_CLEFAIRY_DANCE
+	scene_script MountMoonSquareNoopScene, SCENE_MOUNTMOONSQUARE_CLEFAIRY_DANCE
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .DisappearMoonStone
-	callback MAPCALLBACK_OBJECTS, .DisappearRock
+	callback MAPCALLBACK_NEWMAP, MountMoonSquareDisappearMoonStoneCallback
+	callback MAPCALLBACK_OBJECTS, MountMoonSquareDisappearRockCallback
 
-.DummyScene:
+MountMoonSquareNoopScene:
 	end
 
-.DisappearMoonStone:
+MountMoonSquareDisappearMoonStoneCallback:
 	setevent EVENT_MOUNT_MOON_SQUARE_HIDDEN_MOON_STONE
 	endcallback
 
-.DisappearRock:
+MountMoonSquareDisappearRockCallback:
 	disappear MOUNTMOONSQUARE_ROCK
 	endcallback
 

--- a/maps/MrPokemonsHouse.asm
+++ b/maps/MrPokemonsHouse.asm
@@ -4,19 +4,19 @@
 
 MrPokemonsHouse_MapScripts:
 	def_scene_scripts
-	scene_script .MeetMrPokemon, SCENE_MRPOKEMONSHOUSE_MEET_MR_POKEMON
-	scene_script .DummyScene,    SCENE_MRPOKEMONSHOUSE_NOOP
+	scene_script MrPokemonsHouseMeetMrPokemonScene, SCENE_MRPOKEMONSHOUSE_MEET_MR_POKEMON
+	scene_script MrPokemonsHouseNoopScene,          SCENE_MRPOKEMONSHOUSE_NOOP
 
 	def_callbacks
 
-.MeetMrPokemon:
-	sdefer .MrPokemonEvent
+MrPokemonsHouseMeetMrPokemonScene:
+	sdefer MrPokemonsHouseMrPokemonEventScript
 	end
 
-.DummyScene:
+MrPokemonsHouseNoopScene:
 	end
 
-.MrPokemonEvent:
+MrPokemonsHouseMrPokemonEventScript:
 	showemote EMOTE_SHOCK, MRPOKEMONSHOUSE_GENTLEMAN, 15
 	turnobject MRPOKEMONSHOUSE_GENTLEMAN, DOWN
 	opentext

--- a/maps/NewBarkTown.asm
+++ b/maps/NewBarkTown.asm
@@ -5,19 +5,19 @@
 
 NewBarkTown_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene0, SCENE_NEWBARKTOWN_TEACHER_STOPS_YOU
-	scene_script .DummyScene1, SCENE_NEWBARKTOWN_NOOP
+	scene_script NewBarkTownNoop1Scene, SCENE_NEWBARKTOWN_TEACHER_STOPS_YOU
+	scene_script NewBarkTownNoop2Scene, SCENE_NEWBARKTOWN_NOOP
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .FlyPoint
+	callback MAPCALLBACK_NEWMAP, NewBarkTownFlypointCallback
 
-.DummyScene0:
+NewBarkTownNoop1Scene:
 	end
 
-.DummyScene1:
+NewBarkTownNoop2Scene:
 	end
 
-.FlyPoint:
+NewBarkTownFlypointCallback:
 	setflag ENGINE_FLYPOINT_NEW_BARK
 	clearevent EVENT_FIRST_TIME_BANKING_WITH_MOM
 	endcallback

--- a/maps/OaksLab.asm
+++ b/maps/OaksLab.asm
@@ -9,7 +9,7 @@ OaksLab_MapScripts:
 
 	def_callbacks
 
-.DummyScene: ; unreferenced
+OaksLabNoopScene: ; unreferenced
 	end
 
 Oak:

--- a/maps/OlivineCity.asm
+++ b/maps/OlivineCity.asm
@@ -6,19 +6,19 @@
 
 OlivineCity_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene0, SCENE_OLIVINECITY_RIVAL_ENCOUNTER
-	scene_script .DummyScene1, SCENE_OLIVINECITY_NOOP
+	scene_script OlivineCityNoop1Scene, SCENE_OLIVINECITY_RIVAL_ENCOUNTER
+	scene_script OlivineCityNoop2Scene, SCENE_OLIVINECITY_NOOP
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .FlyPoint
+	callback MAPCALLBACK_NEWMAP, OlivineCityFlypointCallback
 
-.DummyScene0:
+OlivineCityNoop1Scene:
 	end
 
-.DummyScene1:
+OlivineCityNoop2Scene:
 	end
 
-.FlyPoint:
+OlivineCityFlypointCallback:
 	setflag ENGINE_FLYPOINT_OLIVINE
 	endcallback
 

--- a/maps/OlivinePort.asm
+++ b/maps/OlivinePort.asm
@@ -9,19 +9,19 @@
 
 OlivinePort_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene0,   SCENE_OLIVINEPORT_ASK_ENTER_SHIP
-	scene_script .LeaveFastShip, SCENE_OLIVINEPORT_LEAVE_SHIP
+	scene_script OlivinePortNoopScene,      SCENE_OLIVINEPORT_ASK_ENTER_SHIP
+	scene_script OlivinePortLeaveShipScene, SCENE_OLIVINEPORT_LEAVE_SHIP
 
 	def_callbacks
 
-.DummyScene0:
+OlivinePortNoopScene:
 	end
 
-.LeaveFastShip:
-	sdefer .LeaveFastShipScript
+OlivinePortLeaveShipScene:
+	sdefer OlivinePortLeaveShipScript
 	end
 
-.LeaveFastShipScript:
+OlivinePortLeaveShipScript:
 	applymovement PLAYER, OlivinePortLeaveFastShipMovement
 	appear OLIVINEPORT_SAILOR1
 	setscene SCENE_OLIVINEPORT_ASK_ENTER_SHIP

--- a/maps/PalletTown.asm
+++ b/maps/PalletTown.asm
@@ -6,9 +6,9 @@ PalletTown_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .FlyPoint
+	callback MAPCALLBACK_NEWMAP, PalletTownFlypointCallback
 
-.FlyPoint:
+PalletTownFlypointCallback:
 	setflag ENGINE_FLYPOINT_PALLET
 	endcallback
 

--- a/maps/PewterCity.asm
+++ b/maps/PewterCity.asm
@@ -9,9 +9,9 @@ PewterCity_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .FlyPoint
+	callback MAPCALLBACK_NEWMAP, PewterCityFlypointCallback
 
-.FlyPoint:
+PewterCityFlypointCallback:
 	setflag ENGINE_FLYPOINT_PEWTER
 	endcallback
 

--- a/maps/PlayersHouse1F.asm
+++ b/maps/PlayersHouse1F.asm
@@ -6,16 +6,16 @@
 
 PlayersHouse1F_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene0, SCENE_PLAYERSHOUSE1F_MEET_MOM
-	scene_script .DummyScene1, SCENE_PLAYERSHOUSE1F_NOOP
+	scene_script PlayersHouse1FMeetMomScene, SCENE_PLAYERSHOUSE1F_MEET_MOM
+	scene_script PlayersHouse1FNoopScene,    SCENE_PLAYERSHOUSE1F_NOOP
 
 	def_callbacks
 
-.DummyScene0:
+PlayersHouse1FMeetMomScene:
 	sdefer MeetMomScript
 	end
 
-.DummyScene1:
+PlayersHouse1FNoopScene:
 	end
 
 MeetMomScript:

--- a/maps/PlayersHouse2F.asm
+++ b/maps/PlayersHouse2F.asm
@@ -8,13 +8,13 @@ PlayersHouse2F_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .InitializeRoom
-	callback MAPCALLBACK_TILES, .SetUpTileDecorations
+	callback MAPCALLBACK_NEWMAP, PlayersHouse2FInitializeRoomCallback
+	callback MAPCALLBACK_TILES, PlayersHouse2FSetUpTileDecorationsCallback
 
-.DummyScene: ; unreferenced
+PlayersHouse2FNoopScene: ; unreferenced
 	end
 
-.InitializeRoom:
+PlayersHouse2FInitializeRoomCallback:
 	special ToggleDecorationsVisibility
 	setevent EVENT_TEMPORARY_UNTIL_MAP_RELOAD_8
 	checkevent EVENT_INITIALIZED_EVENTS
@@ -25,7 +25,7 @@ PlayersHouse2F_MapScripts:
 .SkipInitialization:
 	endcallback
 
-.SetUpTileDecorations:
+PlayersHouse2FSetUpTileDecorationsCallback:
 	special ToggleMaptileDecorations
 	endcallback
 

--- a/maps/Pokecenter2F.asm
+++ b/maps/Pokecenter2F.asm
@@ -6,33 +6,32 @@
 
 Pokecenter2F_MapScripts:
 	def_scene_scripts
-	scene_script .Scene0, SCENE_POKECENTER2F_NOOP
-	scene_script .Scene1, SCENE_POKECENTER2F_LEAVE_TRADE_CENTER
-	scene_script .Scene2, SCENE_POKECENTER2F_LEAVE_COLOSSEUM
-	scene_script .Scene3, SCENE_POKECENTER2F_LEAVE_TIME_CAPSULE
+	scene_script Pokecenter2FCheckMysteryGiftScene, SCENE_POKECENTER2F_CHECK_MYSTERY_GIFT
+	scene_script Pokecenter2FLeaveTradeCenterScene, SCENE_POKECENTER2F_LEAVE_TRADE_CENTER
+	scene_script Pokecenter2FLeaveColosseumScene,   SCENE_POKECENTER2F_LEAVE_COLOSSEUM
+	scene_script Pokecenter2FLeaveTimeCapsuleScene, SCENE_POKECENTER2F_LEAVE_TIME_CAPSULE
 
 	def_callbacks
 
-.Scene0:
+Pokecenter2FCheckMysteryGiftScene:
 	special CheckMysteryGift
-	ifequal $0, .Scene0Done
+	ifequal $0, .done
 	clearevent EVENT_MYSTERY_GIFT_DELIVERY_GUY
 	checkevent EVENT_TEMPORARY_UNTIL_MAP_RELOAD_2
-	iftrue .Scene0Done
+	iftrue .done
 	sdefer Pokecenter2F_AppearMysteryGiftDeliveryGuy
-
-.Scene0Done:
+.done
 	end
 
-.Scene1:
+Pokecenter2FLeaveTradeCenterScene:
 	sdefer Script_LeftCableTradeCenter
 	end
 
-.Scene2:
+Pokecenter2FLeaveColosseumScene:
 	sdefer Script_LeftCableColosseum
 	end
 
-.Scene3:
+Pokecenter2FLeaveTimeCapsuleScene:
 	sdefer Script_LeftTimeCapsule
 	end
 
@@ -283,7 +282,7 @@ Script_LeftCableTradeCenter:
 	applymovement POKECENTER2F_TRADE_RECEPTIONIST, Pokecenter2FMovementData_ReceptionistStepsRightLooksDown_3
 	applymovement PLAYER, Pokecenter2FMovementData_PlayerTakesThreeStepsDown
 	applymovement POKECENTER2F_TRADE_RECEPTIONIST, Pokecenter2FMovementData_ReceptionistStepsRightAndDown
-	setscene SCENE_POKECENTER2F_NOOP
+	setscene SCENE_POKECENTER2F_CHECK_MYSTERY_GIFT
 	setmapscene TRADE_CENTER, SCENE_TRADECENTER_INITIALIZE
 	end
 
@@ -292,7 +291,7 @@ Script_LeftCableColosseum:
 	applymovement POKECENTER2F_BATTLE_RECEPTIONIST, Pokecenter2FMovementData_ReceptionistStepsRightLooksDown_3
 	applymovement PLAYER, Pokecenter2FMovementData_PlayerTakesThreeStepsDown
 	applymovement POKECENTER2F_BATTLE_RECEPTIONIST, Pokecenter2FMovementData_ReceptionistStepsRightAndDown
-	setscene SCENE_POKECENTER2F_NOOP
+	setscene SCENE_POKECENTER2F_CHECK_MYSTERY_GIFT
 	setmapscene COLOSSEUM, SCENE_COLOSSEUM_INITIALIZE
 	end
 
@@ -301,7 +300,7 @@ Script_LeftTimeCapsule:
 	applymovement POKECENTER2F_TIME_CAPSULE_RECEPTIONIST, Pokecenter2FMovementData_ReceptionistStepsLeftLooksRight
 	applymovement PLAYER, Pokecenter2FMovementData_PlayerTakesTwoStepsDown
 	applymovement POKECENTER2F_TIME_CAPSULE_RECEPTIONIST, Pokecenter2FMovementData_ReceptionistStepsRightLooksDown_2
-	setscene SCENE_POKECENTER2F_NOOP
+	setscene SCENE_POKECENTER2F_CHECK_MYSTERY_GIFT
 	setmapscene TIME_CAPSULE, SCENE_TIMECAPSULE_INITIALIZE
 	end
 

--- a/maps/PowerPlant.asm
+++ b/maps/PowerPlant.asm
@@ -8,15 +8,15 @@
 
 PowerPlant_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene0, SCENE_POWERPLANT_NOOP
-	scene_script .DummyScene1, SCENE_POWERPLANT_GUARD_GETS_PHONE_CALL
+	scene_script PowerPlantNoop1Scene, SCENE_POWERPLANT_NOOP
+	scene_script PowerPlantNoop2Scene, SCENE_POWERPLANT_GUARD_GETS_PHONE_CALL
 
 	def_callbacks
 
-.DummyScene0:
+PowerPlantNoop1Scene:
 	end
 
-.DummyScene1:
+PowerPlantNoop2Scene:
 	end
 
 PowerPlantGuardPhoneScript:

--- a/maps/RadioTower2F.asm
+++ b/maps/RadioTower2F.asm
@@ -14,7 +14,7 @@ RadioTower2F_MapScripts:
 
 	def_callbacks
 
-RadioTower2FUnusedDummyScene: ; unreferenced
+RadioTower2FNoopScene: ; unreferenced
 	end
 
 RadioTower2FSuperNerdScript:

--- a/maps/RadioTower3F.asm
+++ b/maps/RadioTower3F.asm
@@ -11,9 +11,9 @@ RadioTower3F_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_TILES, .CardKeyShutterCallback
+	callback MAPCALLBACK_TILES, RadioTower3FCardKeyShutterCallback
 
-.CardKeyShutterCallback:
+RadioTower3FCardKeyShutterCallback:
 	checkevent EVENT_USED_THE_CARD_KEY_IN_THE_RADIO_TOWER
 	iftrue .Change
 	endcallback

--- a/maps/RadioTower5F.asm
+++ b/maps/RadioTower5F.asm
@@ -6,19 +6,19 @@
 
 RadioTower5F_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene0, SCENE_RADIOTOWER5F_FAKE_DIRECTOR
-	scene_script .DummyScene1, SCENE_RADIOTOWER5F_ROCKET_BOSS
-	scene_script .DummyScene2, SCENE_RADIOTOWER5F_NOOP
+	scene_script RadioTower5FNoop1Scene, SCENE_RADIOTOWER5F_FAKE_DIRECTOR
+	scene_script RadioTower5FNoop2Scene, SCENE_RADIOTOWER5F_ROCKET_BOSS
+	scene_script RadioTower5FNoop3Scene, SCENE_RADIOTOWER5F_NOOP
 
 	def_callbacks
 
-.DummyScene0:
+RadioTower5FNoop1Scene:
 	end
 
-.DummyScene1:
+RadioTower5FNoop2Scene:
 	end
 
-.DummyScene2:
+RadioTower5FNoop3Scene:
 	end
 
 FakeDirectorScript:
@@ -75,7 +75,7 @@ TrainerExecutivef1:
 	closetext
 	end
 
-RadioTower5FRocketBossScene:
+RadioTower5FRocketBossScript:
 	applymovement PLAYER, RadioTower5FPlayerTwoStepsLeftMovement
 	playmusic MUSIC_ROCKET_ENCOUNTER
 	turnobject RADIOTOWER5F_ROCKET, RIGHT
@@ -452,7 +452,7 @@ RadioTower5F_MapEvents:
 
 	def_coord_events
 	coord_event  0,  3, SCENE_RADIOTOWER5F_FAKE_DIRECTOR, FakeDirectorScript
-	coord_event 16,  5, SCENE_RADIOTOWER5F_ROCKET_BOSS, RadioTower5FRocketBossScene
+	coord_event 16,  5, SCENE_RADIOTOWER5F_ROCKET_BOSS, RadioTower5FRocketBossScript
 
 	def_bg_events
 	bg_event  3,  0, BGEVENT_READ, RadioTower5FDirectorsOfficeSign

--- a/maps/RedsHouse1F.asm
+++ b/maps/RedsHouse1F.asm
@@ -3,11 +3,11 @@
 
 RedsHouse1F_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene ; unusable
+	scene_script RedHouse1FNoopScene ; unusable
 
 	def_callbacks
 
-.DummyScene:
+RedHouse1FNoopScene:
 	end
 
 RedsMom:

--- a/maps/Route16.asm
+++ b/maps/Route16.asm
@@ -2,9 +2,9 @@ Route16_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .AlwaysOnBike
+	callback MAPCALLBACK_NEWMAP, Route16AlwaysOnBikeCallback
 
-.AlwaysOnBike:
+Route16AlwaysOnBikeCallback:
 	readvar VAR_YCOORD
 	ifless 5, .CanWalk
 	readvar VAR_XCOORD

--- a/maps/Route16Gate.asm
+++ b/maps/Route16Gate.asm
@@ -3,11 +3,11 @@
 
 Route16Gate_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene, SCENE_ROUTE16GATE_BICYCLE_CHECK
+	scene_script Route16GateNoopScene, SCENE_ROUTE16GATE_BICYCLE_CHECK
 
 	def_callbacks
 
-.DummyScene:
+Route16GateNoopScene:
 	end
 
 Route16GateOfficerScript:

--- a/maps/Route17.asm
+++ b/maps/Route17.asm
@@ -8,9 +8,9 @@ Route17_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .AlwaysOnBike
+	callback MAPCALLBACK_NEWMAP, Route17AlwaysOnBikeCallback
 
-.AlwaysOnBike:
+Route17AlwaysOnBikeCallback:
 	setflag ENGINE_ALWAYS_ON_BIKE
 	setflag ENGINE_DOWNHILL
 	endcallback

--- a/maps/Route17Route18Gate.asm
+++ b/maps/Route17Route18Gate.asm
@@ -3,11 +3,11 @@
 
 Route17Route18Gate_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene, SCENE_ROUTE17ROUTE18GATE_BICYCLE_CHECK
+	scene_script Route17Route18GateNoopScene, SCENE_ROUTE17ROUTE18GATE_BICYCLE_CHECK
 
 	def_callbacks
 
-.DummyScene:
+Route17Route18GateNoopScene:
 	end
 
 Route17Route18GateOfficerScript:

--- a/maps/Route19.asm
+++ b/maps/Route19.asm
@@ -10,9 +10,9 @@ Route19_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_TILES, .ClearRocks
+	callback MAPCALLBACK_TILES, Route19ClearRocksCallback
 
-.ClearRocks:
+Route19ClearRocksCallback:
 	checkevent EVENT_CINNABAR_ROCKS_CLEARED
 	iftrue .Done
 	changeblock  6,  6, $7a ; rock

--- a/maps/Route20.asm
+++ b/maps/Route20.asm
@@ -7,9 +7,9 @@ Route20_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .ClearRocks
+	callback MAPCALLBACK_NEWMAP, Route20ClearRocksCallback
 
-.ClearRocks:
+Route20ClearRocksCallback:
 	setevent EVENT_CINNABAR_ROCKS_CLEARED
 	endcallback
 

--- a/maps/Route23.asm
+++ b/maps/Route23.asm
@@ -2,9 +2,9 @@ Route23_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .FlyPoint
+	callback MAPCALLBACK_NEWMAP, Route23FlypointCallback
 
-.FlyPoint:
+Route23FlypointCallback:
 	setflag ENGINE_FLYPOINT_INDIGO_PLATEAU
 	endcallback
 

--- a/maps/Route25.asm
+++ b/maps/Route25.asm
@@ -13,15 +13,15 @@
 
 Route25_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene0, SCENE_ROUTE25_NOOP
-	scene_script .DummyScene1, SCENE_ROUTE25_MISTYS_DATE
+	scene_script Route25Noop1Scene, SCENE_ROUTE25_NOOP
+	scene_script Route25Noop2Scene, SCENE_ROUTE25_MISTYS_DATE
 
 	def_callbacks
 
-.DummyScene0:
+Route25Noop1Scene:
 	end
 
-.DummyScene1:
+Route25Noop2Scene:
 	end
 
 Route25MistyDate1Script:

--- a/maps/Route27.asm
+++ b/maps/Route27.asm
@@ -11,15 +11,15 @@
 
 Route27_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene0, SCENE_ROUTE27_FIRST_STEP_INTO_KANTO
-	scene_script .DummyScene1, SCENE_ROUTE27_NOOP
+	scene_script Route27Noop1Scene, SCENE_ROUTE27_FIRST_STEP_INTO_KANTO
+	scene_script Route27Noop2Scene, SCENE_ROUTE27_NOOP
 
 	def_callbacks
 
-.DummyScene0:
+Route27Noop1Scene:
 	end
 
-.DummyScene1:
+Route27Noop2Scene:
 	end
 
 FirstStepIntoKantoLeftScene:

--- a/maps/Route28SteelWingHouse.asm
+++ b/maps/Route28SteelWingHouse.asm
@@ -4,11 +4,11 @@
 
 Route28SteelWingHouse_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene ; unusable
+	scene_script Route28SteelWingHouseNoopScene ; unusable
 
 	def_callbacks
 
-.DummyScene:
+Route28SteelWingHouseNoopScene:
 	end
 
 Celebrity:

--- a/maps/Route29.asm
+++ b/maps/Route29.asm
@@ -10,19 +10,19 @@
 
 Route29_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene0, SCENE_ROUTE29_NOOP
-	scene_script .DummyScene1, SCENE_ROUTE29_CATCH_TUTORIAL
+	scene_script Route29Noop1Scene, SCENE_ROUTE29_NOOP
+	scene_script Route29Noop2Scene, SCENE_ROUTE29_CATCH_TUTORIAL
 
 	def_callbacks
-	callback MAPCALLBACK_OBJECTS, .Tuscany
+	callback MAPCALLBACK_OBJECTS, Route29TuscanyCallback
 
-.DummyScene0:
+Route29Noop1Scene:
 	end
 
-.DummyScene1:
+Route29Noop2Scene:
 	end
 
-.Tuscany:
+Route29TuscanyCallback:
 	checkflag ENGINE_ZEPHYRBADGE
 	iftrue .DoesTuscanyAppear
 

--- a/maps/Route31.asm
+++ b/maps/Route31.asm
@@ -11,9 +11,9 @@ Route31_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .CheckMomCall
+	callback MAPCALLBACK_NEWMAP, Route31CheckMomCallCallback
 
-.CheckMomCall:
+Route31CheckMomCallCallback:
 	checkevent EVENT_TALKED_TO_MOM_AFTER_MYSTERY_EGG_QUEST
 	iffalse .DoMomCall
 	endcallback

--- a/maps/Route32.asm
+++ b/maps/Route32.asm
@@ -16,23 +16,23 @@
 
 Route32_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene0, SCENE_ROUTE32_COOLTRAINER_M_BLOCKS
-	scene_script .DummyScene1, SCENE_ROUTE32_OFFER_SLOWPOKETAIL
-	scene_script .DummyScene2, SCENE_ROUTE32_NOOP
+	scene_script Route32Noop1Scene, SCENE_ROUTE32_COOLTRAINER_M_BLOCKS
+	scene_script Route32Noop2Scene, SCENE_ROUTE32_OFFER_SLOWPOKETAIL
+	scene_script Route32Noop3Scene, SCENE_ROUTE32_NOOP
 
 	def_callbacks
-	callback MAPCALLBACK_OBJECTS, .Frieda
+	callback MAPCALLBACK_OBJECTS, Route32FriedaCallback
 
-.DummyScene0:
+Route32Noop1Scene:
 	end
 
-.DummyScene1:
+Route32Noop2Scene:
 	end
 
-.DummyScene2:
+Route32Noop3Scene:
 	end
 
-.Frieda:
+Route32FriedaCallback:
 	readvar VAR_WEEKDAY
 	ifequal FRIDAY, .FriedaAppears
 	disappear ROUTE32_FRIEDA

--- a/maps/Route34.asm
+++ b/maps/Route34.asm
@@ -16,9 +16,9 @@ Route34_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_OBJECTS, .EggCheckCallback
+	callback MAPCALLBACK_OBJECTS, Route34EggCheckCallback
 
-.EggCheckCallback:
+Route34EggCheckCallback:
 	checkflag ENGINE_DAY_CARE_MAN_HAS_EGG
 	iftrue .PutDayCareManOutside
 	clearevent EVENT_DAY_CARE_MAN_IN_DAY_CARE

--- a/maps/Route35NationalParkGate.asm
+++ b/maps/Route35NationalParkGate.asm
@@ -5,41 +5,41 @@
 
 Route35NationalParkGate_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene0,       SCENE_ROUTE35NATIONALPARKGATE_NOOP
-	scene_script .DummyScene1,       SCENE_ROUTE35NATIONALPARKGATE_UNUSED
-	scene_script .LeaveContestEarly, SCENE_ROUTE35NATIONALPARKGATE_LEAVE_CONTEST_EARLY
+	scene_script Route35NationalParkGateNoop1Scene,             SCENE_ROUTE35NATIONALPARKGATE_NOOP
+	scene_script Route35NationalParkGateNoop2Scene,             SCENE_ROUTE35NATIONALPARKGATE_UNUSED
+	scene_script Route35NationalParkGateLeaveContestEarlyScene, SCENE_ROUTE35NATIONALPARKGATE_LEAVE_CONTEST_EARLY
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .CheckIfContestRunning
-	callback MAPCALLBACK_OBJECTS, .CheckIfContestAvailable
+	callback MAPCALLBACK_NEWMAP, Route35NationalParkGateCheckIfContestRunningCallback
+	callback MAPCALLBACK_OBJECTS, Route35NationalParkGateCheckIfContestAvailableCallback
 
-.DummyScene0:
+Route35NationalParkGateNoop1Scene:
 	end
 
-.DummyScene1:
+Route35NationalParkGateNoop2Scene:
 	end
 
-.LeaveContestEarly:
-	sdefer .LeavingContestEarly
+Route35NationalParkGateLeaveContestEarlyScene:
+	sdefer Route35NationalParkGateLeavingContestEarlyScript
 	end
 
-.CheckIfContestRunning:
+Route35NationalParkGateCheckIfContestRunningCallback:
 	checkflag ENGINE_BUG_CONTEST_TIMER
-	iftrue .BugContestIsRunning
+	iftrue Route35NationalParkBugContestIsRunningScript
 	setscene SCENE_ROUTE35NATIONALPARKGATE_NOOP
 	endcallback
 
-.BugContestIsRunning:
+Route35NationalParkBugContestIsRunningScript:
 	setscene SCENE_ROUTE35NATIONALPARKGATE_LEAVE_CONTEST_EARLY
 	endcallback
 
-.CheckIfContestAvailable:
+Route35NationalParkGateCheckIfContestAvailableCallback:
 	readvar VAR_WEEKDAY
 	ifequal TUESDAY, .SetContestOfficer
 	ifequal THURSDAY, .SetContestOfficer
 	ifequal SATURDAY, .SetContestOfficer
 	checkflag ENGINE_BUG_CONTEST_TIMER
-	iftrue .BugContestIsRunning
+	iftrue Route35NationalParkBugContestIsRunningScript
 	disappear ROUTE35NATIONALPARKGATE_OFFICER1
 	appear ROUTE35NATIONALPARKGATE_YOUNGSTER
 	appear ROUTE35NATIONALPARKGATE_OFFICER2
@@ -51,7 +51,7 @@ Route35NationalParkGate_MapScripts:
 	disappear ROUTE35NATIONALPARKGATE_OFFICER2
 	endcallback
 
-.LeavingContestEarly:
+Route35NationalParkGateLeavingContestEarlyScript:
 	applymovement PLAYER, Route35NationalParkGatePlayerApproachOfficer1Movement
 	turnobject ROUTE35NATIONALPARKGATE_OFFICER1, RIGHT
 	opentext

--- a/maps/Route36.asm
+++ b/maps/Route36.asm
@@ -11,9 +11,9 @@ Route36_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_OBJECTS, .ArthurCallback
+	callback MAPCALLBACK_OBJECTS, Route36ArthurCallback
 
-.ArthurCallback:
+Route36ArthurCallback:
 	readvar VAR_WEEKDAY
 	ifequal THURSDAY, .ArthurAppears
 	disappear ROUTE36_ARTHUR

--- a/maps/Route36NationalParkGate.asm
+++ b/maps/Route36NationalParkGate.asm
@@ -14,25 +14,25 @@
 
 Route36NationalParkGate_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene0,       SCENE_ROUTE36NATIONALPARKGATE_NOOP
-	scene_script .DummyScene1,       SCENE_ROUTE36NATIONALPARKGATE_UNUSED
-	scene_script .LeaveContestEarly, SCENE_ROUTE36NATIONALPARKGATE_LEAVE_CONTEST_EARLY
+	scene_script Route36NationalParkGateNoop1Scene,             SCENE_ROUTE36NATIONALPARKGATE_NOOP
+	scene_script Route36NationalParkGateNoop2Scene,             SCENE_ROUTE36NATIONALPARKGATE_UNUSED
+	scene_script Route36NationalParkGateLeaveContestEarlyScene, SCENE_ROUTE36NATIONALPARKGATE_LEAVE_CONTEST_EARLY
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .CheckIfContestRunning
-	callback MAPCALLBACK_OBJECTS, .CheckIfContestAvailable
+	callback MAPCALLBACK_NEWMAP, Route36NationalParkGateCheckIfContestRunningCallback
+	callback MAPCALLBACK_OBJECTS, Route36NationalParkGateCheckIfContestAvailableCallback
 
-.DummyScene0:
+Route36NationalParkGateNoop1Scene:
 	end
 
-.DummyScene1:
+Route36NationalParkGateNoop2Scene:
 	end
 
-.LeaveContestEarly:
-	sdefer .LeavingContestEarly
+Route36NationalParkGateLeaveContestEarlyScene:
+	sdefer Route36NationalParkGateLeavingContestEarlyScript
 	end
 
-.CheckIfContestRunning:
+Route36NationalParkGateCheckIfContestRunningCallback:
 	checkflag ENGINE_BUG_CONTEST_TIMER
 	iftrue .BugContestIsRunning
 	setscene SCENE_ROUTE36NATIONALPARKGATE_NOOP
@@ -42,7 +42,7 @@ Route36NationalParkGate_MapScripts:
 	setscene SCENE_ROUTE36NATIONALPARKGATE_LEAVE_CONTEST_EARLY
 	endcallback
 
-.CheckIfContestAvailable:
+Route36NationalParkGateCheckIfContestAvailableCallback:
 	checkevent EVENT_WARPED_FROM_ROUTE_35_NATIONAL_PARK_GATE
 	iftrue .Return
 	readvar VAR_WEEKDAY
@@ -61,7 +61,7 @@ Route36NationalParkGate_MapScripts:
 .Return:
 	endcallback
 
-.LeavingContestEarly:
+Route36NationalParkGateLeavingContestEarlyScript:
 	turnobject PLAYER, UP
 	opentext
 	readvar VAR_CONTESTMINUTES

--- a/maps/Route37.asm
+++ b/maps/Route37.asm
@@ -11,9 +11,9 @@ Route37_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_OBJECTS, .Sunny
+	callback MAPCALLBACK_OBJECTS, Route37SunnyCallback
 
-.Sunny:
+Route37SunnyCallback:
 	readvar VAR_WEEKDAY
 	ifequal SUNDAY, .SunnyAppears
 	disappear ROUTE37_SUNNY

--- a/maps/Route40.asm
+++ b/maps/Route40.asm
@@ -13,9 +13,9 @@ Route40_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_OBJECTS, .MonicaCallback
+	callback MAPCALLBACK_OBJECTS, Route40MonicaCallback
 
-.MonicaCallback:
+Route40MonicaCallback:
 	readvar VAR_WEEKDAY
 	ifequal MONDAY, .MonicaAppears
 	disappear ROUTE40_MONICA

--- a/maps/Route43.asm
+++ b/maps/Route43.asm
@@ -12,9 +12,9 @@ Route43_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .CheckIfRockets
+	callback MAPCALLBACK_NEWMAP, Route43CheckIfRocketsScene
 
-.CheckIfRockets:
+Route43CheckIfRocketsScene:
 	checkevent EVENT_CLEARED_ROCKET_HIDEOUT
 	iftrue .NoRockets
 	setmapscene ROUTE_43_GATE, SCENE_ROUTE43GATE_ROCKET_SHAKEDOWN

--- a/maps/Route43Gate.asm
+++ b/maps/Route43Gate.asm
@@ -7,20 +7,20 @@ DEF ROUTE43GATE_TOLL EQU 1000
 
 Route43Gate_MapScripts:
 	def_scene_scripts
-	scene_script .RocketShakedown, SCENE_ROUTE43GATE_ROCKET_SHAKEDOWN
-	scene_script .DummyScene,      SCENE_ROUTE43GATE_NOOP
+	scene_script Route43GateRocketShakedownScene, SCENE_ROUTE43GATE_ROCKET_SHAKEDOWN
+	scene_script Route43GateNoopScene,            SCENE_ROUTE43GATE_NOOP
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .CheckIfRockets
+	callback MAPCALLBACK_NEWMAP, Route43GateCheckIfRocketsCallback
 
-.RocketShakedown:
-	sdefer .RocketTakeover
+Route43GateRocketShakedownScene:
+	sdefer Route43GateRocketTakeoverScript
 	end
 
-.DummyScene:
+Route43GateNoopScene:
 	end
 
-.CheckIfRockets:
+Route43GateCheckIfRocketsCallback:
 	checkevent EVENT_CLEARED_ROCKET_HIDEOUT
 	iftrue .NoRockets
 	setmapscene ROUTE_43, 0 ; Route 43 does not have a scene variable
@@ -30,7 +30,7 @@ Route43Gate_MapScripts:
 	setmapscene ROUTE_43, 1 ; Route 43 does not have a scene variable
 	endcallback
 
-.RocketTakeover:
+Route43GateRocketTakeoverScript:
 	playmusic MUSIC_ROCKET_ENCOUNTER
 	readvar VAR_FACING
 	ifequal DOWN, RocketScript_Southbound

--- a/maps/Route6SaffronGate.asm
+++ b/maps/Route6SaffronGate.asm
@@ -3,11 +3,11 @@
 
 Route6SaffronGate_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene ; unusable
+	scene_script Route6SaffronGateNoopScene ; unusable
 
 	def_callbacks
 
-.DummyScene:
+Route6SaffronGateNoopScene:
 	end
 
 Route6SaffronGuardScript:

--- a/maps/RuinsOfAlphAerodactylChamber.asm
+++ b/maps/RuinsOfAlphAerodactylChamber.asm
@@ -2,9 +2,9 @@ RuinsOfAlphAerodactylChamber_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_TILES, .HiddenDoors
+	callback MAPCALLBACK_TILES, RuinsOfAlphAerodactylChamberHiddenDoorsCallback
 
-.HiddenDoors:
+RuinsOfAlphAerodactylChamberHiddenDoorsCallback:
 	checkevent EVENT_SOLVED_AERODACTYL_PUZZLE
 	iffalse .FloorClosed
 	endcallback

--- a/maps/RuinsOfAlphHoOhChamber.asm
+++ b/maps/RuinsOfAlphHoOhChamber.asm
@@ -2,9 +2,9 @@ RuinsOfAlphHoOhChamber_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_TILES, .HiddenDoors
+	callback MAPCALLBACK_TILES, RuinsOfAlphHoOhChamberHiddenDoorsCallback
 
-.HiddenDoors:
+RuinsOfAlphHoOhChamberHiddenDoorsCallback:
 	checkevent EVENT_SOLVED_HO_OH_PUZZLE
 	iffalse .FloorClosed
 	endcallback

--- a/maps/RuinsOfAlphInnerChamber.asm
+++ b/maps/RuinsOfAlphInnerChamber.asm
@@ -5,19 +5,19 @@
 
 RuinsOfAlphInnerChamber_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene0, SCENE_RUINSOFALPHINNERCHAMBER_NOOP
-	scene_script .UnownAppear, SCENE_RUINSOFALPHINNERCHAMBER_STRANGE_PRESENCE
+	scene_script RuinsOfAlphInnerChamberNoopScene,            SCENE_RUINSOFALPHINNERCHAMBER_NOOP
+	scene_script RuinsOfAlphInnerChamberStrangePresenceScene, SCENE_RUINSOFALPHINNERCHAMBER_STRANGE_PRESENCE
 
 	def_callbacks
 
-.DummyScene0:
+RuinsOfAlphInnerChamberNoopScene:
 	end
 
-.UnownAppear:
-	sdefer .StrangePresenceScript
+RuinsOfAlphInnerChamberStrangePresenceScene:
+	sdefer RuinsOfAlphInnerChamberStrangePresenceScript
 	end
 
-.StrangePresenceScript:
+RuinsOfAlphInnerChamberStrangePresenceScript:
 	opentext
 	writetext RuinsOfAlphStrangePresenceText
 	waitbutton

--- a/maps/RuinsOfAlphKabutoChamber.asm
+++ b/maps/RuinsOfAlphKabutoChamber.asm
@@ -5,12 +5,12 @@ RuinsOfAlphKabutoChamber_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_TILES, RuinsOfAlphKabutoChamberHiddenDoors
+	callback MAPCALLBACK_TILES, RuinsOfAlphKabutoChamberHiddenDoorsCallback
 
 RuinsOfAlphKabutoChamberReceptionistScript:
 	jumptextfaceplayer RuinsOfAlphKabutoChamberReceptionistText
 
-RuinsOfAlphKabutoChamberHiddenDoors:
+RuinsOfAlphKabutoChamberHiddenDoorsCallback:
 	checkevent EVENT_SOLVED_KABUTO_PUZZLE
 	iffalse .FloorClosed
 	endcallback

--- a/maps/RuinsOfAlphOmanyteChamber.asm
+++ b/maps/RuinsOfAlphOmanyteChamber.asm
@@ -2,9 +2,9 @@ RuinsOfAlphOmanyteChamber_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_TILES, .HiddenDoors
+	callback MAPCALLBACK_TILES, RuinsOfAlphOmanyteChamberHiddenDoorsCallback
 
-.HiddenDoors:
+RuinsOfAlphOmanyteChamberHiddenDoorsCallback:
 	checkevent EVENT_SOLVED_OMANYTE_PUZZLE
 	iffalse .FloorClosed
 	endcallback

--- a/maps/RuinsOfAlphOutside.asm
+++ b/maps/RuinsOfAlphOutside.asm
@@ -7,19 +7,19 @@
 
 RuinsOfAlphOutside_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene0, SCENE_RUINSOFALPHOUTSIDE_NOOP
-	scene_script .DummyScene1, SCENE_RUINSOFALPHOUTSIDE_GET_UNOWN_DEX
+	scene_script RuinsOfAlphOutsideNoop1Scene, SCENE_RUINSOFALPHOUTSIDE_NOOP
+	scene_script RuinsOfAlphOutsideNoop2Scene, SCENE_RUINSOFALPHOUTSIDE_GET_UNOWN_DEX
 
 	def_callbacks
-	callback MAPCALLBACK_OBJECTS, .ScientistCallback
+	callback MAPCALLBACK_OBJECTS, RuinsOfAlphOutsideScientistCallback
 
-.DummyScene0:
+RuinsOfAlphOutsideNoop1Scene:
 	end
 
-.DummyScene1:
+RuinsOfAlphOutsideNoop2Scene:
 	end
 
-.ScientistCallback:
+RuinsOfAlphOutsideScientistCallback:
 	checkflag ENGINE_UNOWN_DEX
 	iftrue .NoScientist
 	checkevent EVENT_MADE_UNOWN_APPEAR_IN_RUINS

--- a/maps/RuinsOfAlphResearchCenter.asm
+++ b/maps/RuinsOfAlphResearchCenter.asm
@@ -5,20 +5,20 @@
 
 RuinsOfAlphResearchCenter_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene0, SCENE_RUINSOFALPHRESEARCHCENTER_NOOP
-	scene_script .GetUnownDex, SCENE_RUINSOFALPHRESEARCHCENTER_GET_UNOWN_DEX
+	scene_script RuinsOfAlphResearchCenterNoopScene,        SCENE_RUINSOFALPHRESEARCHCENTER_NOOP
+	scene_script RuinsOfAlphResearchCenterGetUnownDexScene, SCENE_RUINSOFALPHRESEARCHCENTER_GET_UNOWN_DEX
 
 	def_callbacks
-	callback MAPCALLBACK_OBJECTS, .ScientistCallback
+	callback MAPCALLBACK_OBJECTS, RuinsOfAlphResearchCenterScientistCallback
 
-.DummyScene0:
+RuinsOfAlphResearchCenterNoopScene:
 	end
 
-.GetUnownDex:
-	sdefer .GetUnownDexScript
+RuinsOfAlphResearchCenterGetUnownDexScene:
+	sdefer RuinsOfAlphResearchCenterGetUnownDexScript
 	end
 
-.ScientistCallback:
+RuinsOfAlphResearchCenterScientistCallback:
 	checkscene
 	ifequal SCENE_RUINSOFALPHRESEARCHCENTER_GET_UNOWN_DEX, .ShowScientist
 	endcallback
@@ -28,7 +28,7 @@ RuinsOfAlphResearchCenter_MapScripts:
 	appear RUINSOFALPHRESEARCHCENTER_SCIENTIST3
 	endcallback
 
-.GetUnownDexScript:
+RuinsOfAlphResearchCenterGetUnownDexScript:
 	applymovement RUINSOFALPHRESEARCHCENTER_SCIENTIST3, RuinsOfAlphResearchCenterApproachesComputerMovement
 	playsound SFX_BOOT_PC
 	pause 60

--- a/maps/SaffronCity.asm
+++ b/maps/SaffronCity.asm
@@ -12,9 +12,9 @@ SaffronCity_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .FlyPoint
+	callback MAPCALLBACK_NEWMAP, SaffronCityFlypointCallback
 
-.FlyPoint:
+SaffronCityFlypointCallback:
 	setflag ENGINE_FLYPOINT_SAFFRON
 	endcallback
 

--- a/maps/SaffronMagnetTrainStation.asm
+++ b/maps/SaffronMagnetTrainStation.asm
@@ -6,11 +6,11 @@
 
 SaffronMagnetTrainStation_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene, SCENE_SAFFRONMAGNETTRAINSTATION_ARRIVE_FROM_GOLDENROD
+	scene_script SaffronMagnetTrainStationNoopScene, SCENE_SAFFRONMAGNETTRAINSTATION_ARRIVE_FROM_GOLDENROD
 
 	def_callbacks
 
-.DummyScene:
+SaffronMagnetTrainStationNoopScene:
 	end
 
 SaffronMagnetTrainStationOfficerScript:

--- a/maps/SeafoamGym.asm
+++ b/maps/SeafoamGym.asm
@@ -4,11 +4,11 @@
 
 SeafoamGym_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene ; unusable
+	scene_script SeafoamGymNoopScene ; unusable
 
 	def_callbacks
 
-.DummyScene:
+SeafoamGymNoopScene:
 	end
 
 SeafoamGymBlaineScript:

--- a/maps/SilverCaveOutside.asm
+++ b/maps/SilverCaveOutside.asm
@@ -2,9 +2,9 @@ SilverCaveOutside_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .FlyPoint
+	callback MAPCALLBACK_NEWMAP, SilverCaveOutsideFlypointCallback
 
-.FlyPoint:
+SilverCaveOutsideFlypointCallback:
 	setflag ENGINE_FLYPOINT_SILVER_CAVE
 	endcallback
 

--- a/maps/SproutTower3F.asm
+++ b/maps/SproutTower3F.asm
@@ -9,15 +9,15 @@
 
 SproutTower3F_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene0, SCENE_SPROUTTOWER3F_RIVAL_ENCOUNTER
-	scene_script .DummyScene1, SCENE_SPROUTTOWER3F_NOOP
+	scene_script SproutTower3FNoop1Scene, SCENE_SPROUTTOWER3F_RIVAL_ENCOUNTER
+	scene_script SproutTower3FNoop2Scene, SCENE_SPROUTTOWER3F_NOOP
 
 	def_callbacks
 
-.DummyScene0:
+SproutTower3FNoop1Scene:
 	end
 
-.DummyScene1:
+SproutTower3FNoop2Scene:
 	end
 
 SproutTower3FRivalScene:

--- a/maps/TeamRocketBaseB1F.asm
+++ b/maps/TeamRocketBaseB1F.asm
@@ -8,15 +8,15 @@
 
 TeamRocketBaseB1F_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene, SCENE_TEAMROCKETBASEB1F_TRAPS
+	scene_script TeamRocketBaseB1FNoopScene, SCENE_TEAMROCKETBASEB1F_TRAPS
 
 	def_callbacks
-	callback MAPCALLBACK_OBJECTS, .HideSecurityGrunt
+	callback MAPCALLBACK_OBJECTS, TeamRocketBaseB1FHideSecurityGruntCallback
 
-.DummyScene:
+TeamRocketBaseB1FNoopScene:
 	end
 
-.HideSecurityGrunt:
+TeamRocketBaseB1FHideSecurityGruntCallback:
 	disappear TEAMROCKETBASEB1F_ROCKET1
 	endcallback
 

--- a/maps/TeamRocketBaseB2F.asm
+++ b/maps/TeamRocketBaseB2F.asm
@@ -16,27 +16,27 @@
 
 TeamRocketBaseB2F_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene0, SCENE_TEAMROCKETBASEB2F_LANCE_HEALS
-	scene_script .DummyScene1, SCENE_TEAMROCKETBASEB2F_ROCKET_BOSS
-	scene_script .DummyScene2, SCENE_TEAMROCKETBASEB2F_ELECTRODES
-	scene_script .DummyScene3, SCENE_TEAMROCKETBASEB2F_NOOP
+	scene_script TeamRocketBaseB2FNoop1Scene, SCENE_TEAMROCKETBASEB2F_LANCE_HEALS
+	scene_script TeamRocketBaseB2FNoop2Scene, SCENE_TEAMROCKETBASEB2F_ROCKET_BOSS
+	scene_script TeamRocketBaseB2FNoop3Scene, SCENE_TEAMROCKETBASEB2F_ELECTRODES
+	scene_script TeamRocketBaseB2FNoop4Scene, SCENE_TEAMROCKETBASEB2F_NOOP
 
 	def_callbacks
-	callback MAPCALLBACK_TILES, .TransmitterDoorCallback
+	callback MAPCALLBACK_TILES, TeamRocketBaseB2FTransmitterDoorCallback
 
-.DummyScene0:
+TeamRocketBaseB2FNoop1Scene:
 	end
 
-.DummyScene1:
+TeamRocketBaseB2FNoop2Scene:
 	end
 
-.DummyScene2:
+TeamRocketBaseB2FNoop3Scene:
 	end
 
-.DummyScene3:
+TeamRocketBaseB2FNoop4Scene:
 	end
 
-.TransmitterDoorCallback:
+TeamRocketBaseB2FTransmitterDoorCallback:
 	checkevent EVENT_OPENED_DOOR_TO_ROCKET_HIDEOUT_TRANSMITTER
 	iftrue .OpenDoor
 	endcallback

--- a/maps/TeamRocketBaseB3F.asm
+++ b/maps/TeamRocketBaseB3F.asm
@@ -15,28 +15,28 @@
 
 TeamRocketBaseB3F_MapScripts:
 	def_scene_scripts
-	scene_script .LanceGetsPassword, SCENE_TEAMROCKETBASEB3F_LANCE_GETS_PASSWORD
-	scene_script .DummyScene1,       SCENE_TEAMROCKETBASEB3F_RIVAL_ENCOUNTER
-	scene_script .DummyScene2,       SCENE_TEAMROCKETBASEB3F_ROCKET_BOSS
-	scene_script .DummyScene3,       SCENE_TEAMROCKETBASEB3F_NOOP
+	scene_script TeamRocketBaseB3FLanceGetsPasswordScene, SCENE_TEAMROCKETBASEB3F_LANCE_GETS_PASSWORD
+	scene_script TeamRocketBaseB3FNoop1Scene,             SCENE_TEAMROCKETBASEB3F_RIVAL_ENCOUNTER
+	scene_script TeamRocketBaseB3FNoop2Scene,             SCENE_TEAMROCKETBASEB3F_ROCKET_BOSS
+	scene_script TeamRocketBaseB3FNoop3Scene,             SCENE_TEAMROCKETBASEB3F_NOOP
 
 	def_callbacks
-	callback MAPCALLBACK_TILES, .CheckGiovanniDoor
+	callback MAPCALLBACK_TILES, TeamRocketBaseB3FCheckGiovanniDoorCallback
 
-.LanceGetsPassword:
+TeamRocketBaseB3FLanceGetsPasswordScene:
 	sdefer LanceGetPasswordScript
 	end
 
-.DummyScene1:
+TeamRocketBaseB3FNoop1Scene:
 	end
 
-.DummyScene2:
+TeamRocketBaseB3FNoop2Scene:
 	end
 
-.DummyScene3:
+TeamRocketBaseB3FNoop3Scene:
 	end
 
-.CheckGiovanniDoor:
+TeamRocketBaseB3FCheckGiovanniDoorCallback:
 	checkevent EVENT_OPENED_DOOR_TO_GIOVANNIS_OFFICE
 	iftrue .OpenSesame
 	endcallback

--- a/maps/TimeCapsule.asm
+++ b/maps/TimeCapsule.asm
@@ -4,20 +4,20 @@
 
 TimeCapsule_MapScripts:
 	def_scene_scripts
-	scene_script .InitializeTimeCapsule, SCENE_TIMECAPSULE_INITIALIZE
-	scene_script .DummyScene,            SCENE_TIMECAPSULE_NOOP
+	scene_script TimeCapsuleInitializeScene, SCENE_TIMECAPSULE_INITIALIZE
+	scene_script TimeCapsuleNoopScene,       SCENE_TIMECAPSULE_NOOP
 
 	def_callbacks
-	callback MAPCALLBACK_OBJECTS, .SetWhichChris
+	callback MAPCALLBACK_OBJECTS, TimeCapsuleSetWhichChrisCallback
 
-.InitializeTimeCapsule:
-	sdefer .InitializeAndPreparePokecenter2F
+TimeCapsuleInitializeScene:
+	sdefer TimeCapsuleInitializeAndPreparePokecenter2FScript
 	end
 
-.DummyScene:
+TimeCapsuleNoopScene:
 	end
 
-.SetWhichChris:
+TimeCapsuleSetWhichChrisCallback:
 	special CableClubCheckWhichChris
 	iffalse .Chris2
 	disappear TIMECAPSULE_CHRIS2
@@ -29,7 +29,7 @@ TimeCapsule_MapScripts:
 	appear TIMECAPSULE_CHRIS2
 	endcallback
 
-.InitializeAndPreparePokecenter2F:
+TimeCapsuleInitializeAndPreparePokecenter2FScript:
 	setscene SCENE_TIMECAPSULE_NOOP
 	setmapscene POKECENTER_2F, SCENE_POKECENTER2F_LEAVE_TIME_CAPSULE
 	end

--- a/maps/TinTowerRoof.asm
+++ b/maps/TinTowerRoof.asm
@@ -5,9 +5,9 @@ TinTowerRoof_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_OBJECTS, .HoOh
+	callback MAPCALLBACK_OBJECTS, TinTowerRoofHoOhCallback
 
-.HoOh:
+TinTowerRoofHoOhCallback:
 	checkevent EVENT_FOUGHT_HO_OH
 	iftrue .NoAppear
 	checkitem RAINBOW_WING

--- a/maps/TradeCenter.asm
+++ b/maps/TradeCenter.asm
@@ -4,20 +4,20 @@
 
 TradeCenter_MapScripts:
 	def_scene_scripts
-	scene_script .InitializeTradeCenter, SCENE_TRADECENTER_INITIALIZE
-	scene_script .DummyScene,            SCENE_TRADECENTER_NOOP
+	scene_script TradeCenterInitializeScene, SCENE_TRADECENTER_INITIALIZE
+	scene_script TradeCenterNoopScene,       SCENE_TRADECENTER_NOOP
 
 	def_callbacks
-	callback MAPCALLBACK_OBJECTS, .SetWhichChris
+	callback MAPCALLBACK_OBJECTS, TradeCenterSetWhichChrisCallback
 
-.InitializeTradeCenter:
-	sdefer .InitializeAndPreparePokecenter2F
+TradeCenterInitializeScene:
+	sdefer TradeCenterInitializeAndPreparePokecenter2FScript
 	end
 
-.DummyScene:
+TradeCenterNoopScene:
 	end
 
-.SetWhichChris:
+TradeCenterSetWhichChrisCallback:
 	special CableClubCheckWhichChris
 	iffalse .Chris2
 	disappear TRADECENTER_CHRIS2
@@ -29,7 +29,7 @@ TradeCenter_MapScripts:
 	appear TRADECENTER_CHRIS2
 	endcallback
 
-.InitializeAndPreparePokecenter2F:
+TradeCenterInitializeAndPreparePokecenter2FScript:
 	setscene SCENE_TRADECENTER_NOOP
 	setmapscene POKECENTER_2F, SCENE_POKECENTER2F_LEAVE_TRADE_CENTER
 	end

--- a/maps/TrainerHouseB1F.asm
+++ b/maps/TrainerHouseB1F.asm
@@ -4,11 +4,11 @@
 
 TrainerHouseB1F_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene, SCENE_TRAINERHOUSEB1F_ASK_BATTLE
+	scene_script TrainerHouseB1FNoopScene, SCENE_TRAINERHOUSEB1F_ASK_BATTLE
 
 	def_callbacks
 
-.DummyScene:
+TrainerHouseB1FNoopScene:
 	end
 
 TrainerHouseReceptionistScript:

--- a/maps/UnionCaveB2F.asm
+++ b/maps/UnionCaveB2F.asm
@@ -10,9 +10,9 @@ UnionCaveB2F_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_OBJECTS, .Lapras
+	callback MAPCALLBACK_OBJECTS, UnionCaveB2FLaprasCallback
 
-.Lapras:
+UnionCaveB2FLaprasCallback:
 	checkflag ENGINE_UNION_CAVE_LAPRAS
 	iftrue .NoAppear
 	readvar VAR_WEEKDAY

--- a/maps/VermilionCity.asm
+++ b/maps/VermilionCity.asm
@@ -10,9 +10,9 @@ VermilionCity_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .FlyPoint
+	callback MAPCALLBACK_NEWMAP, VermilionCityFlypointCallback
 
-.FlyPoint:
+VermilionCityFlypointCallback:
 	setflag ENGINE_FLYPOINT_VERMILION
 	endcallback
 

--- a/maps/VermilionPort.asm
+++ b/maps/VermilionPort.asm
@@ -5,24 +5,24 @@
 
 VermilionPort_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene0,   SCENE_VERMILIONPORT_ASK_ENTER_SHIP
-	scene_script .LeaveFastShip, SCENE_VERMILIONPORT_LEAVE_SHIP
+	scene_script VermilionPortNoopScene,      SCENE_VERMILIONPORT_ASK_ENTER_SHIP
+	scene_script VermilionPortLeaveShipScene, SCENE_VERMILIONPORT_LEAVE_SHIP
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .FlyPoint
+	callback MAPCALLBACK_NEWMAP, VermilionPortFlypointCallback
 
-.DummyScene0:
+VermilionPortNoopScene:
 	end
 
-.LeaveFastShip:
-	sdefer .LeaveFastShipScript
+VermilionPortLeaveShipScene:
+	sdefer VermilionPortLeaveShipScript
 	end
 
-.FlyPoint:
+VermilionPortFlypointCallback:
 	setflag ENGINE_FLYPOINT_VERMILION
 	endcallback
 
-.LeaveFastShipScript:
+VermilionPortLeaveShipScript:
 	applymovement PLAYER, VermilionPortLeaveFastShipMovement
 	appear VERMILIONPORT_SAILOR1
 	setscene SCENE_VERMILIONPORT_ASK_ENTER_SHIP

--- a/maps/VictoryRoad.asm
+++ b/maps/VictoryRoad.asm
@@ -8,15 +8,15 @@
 
 VictoryRoad_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene0, SCENE_VICTORYROAD_RIVAL_BATTLE
-	scene_script .DummyScene1, SCENE_VICTORYROAD_NOOP
+	scene_script VictoryRoadNoop1Scene, SCENE_VICTORYROAD_RIVAL_BATTLE
+	scene_script VictoryRoadNoop2Scene, SCENE_VICTORYROAD_NOOP
 
 	def_callbacks
 
-.DummyScene0:
+VictoryRoadNoop1Scene:
 	end
 
-.DummyScene1:
+VictoryRoadNoop2Scene:
 	end
 
 VictoryRoadRivalLeft:

--- a/maps/VictoryRoadGate.asm
+++ b/maps/VictoryRoadGate.asm
@@ -5,24 +5,24 @@
 
 VictoryRoadGate_MapScripts:
 	def_scene_scripts
-	scene_script .DummyScene0, SCENE_VICTORYROADGATE_BADGE_CHECK
-	scene_script .DummyScene1, SCENE_VICTORYROADGATE_NOOP
+	scene_script VictoryRoadGateNoop1Scene, SCENE_VICTORYROADGATE_BADGE_CHECK
+	scene_script VictoryRoadGateNoop2Scene, SCENE_VICTORYROADGATE_NOOP
 
 	def_callbacks
 
-.DummyScene0:
+VictoryRoadGateNoop1Scene:
 	end
 
-.DummyScene1:
+VictoryRoadGateNoop2Scene:
 	end
 
-VictoryRoadGateBadgeCheckScene:
+VictoryRoadGateBadgeCheckScript:
 	turnobject PLAYER, LEFT
-	sjump VictoryRoadGateBadgeCheckScript
+	sjump _VictoryRoadGateBadgeCheckScript
 
 VictoryRoadGateOfficerScript:
 	faceplayer
-VictoryRoadGateBadgeCheckScript:
+_VictoryRoadGateBadgeCheckScript:
 	opentext
 	writetext VictoryRoadGateOfficerText
 	promptbutton
@@ -109,7 +109,7 @@ VictoryRoadGate_MapEvents:
 	warp_event  2,  7, ROUTE_28, 2
 
 	def_coord_events
-	coord_event 10, 11, SCENE_VICTORYROADGATE_BADGE_CHECK, VictoryRoadGateBadgeCheckScene
+	coord_event 10, 11, SCENE_VICTORYROADGATE_BADGE_CHECK, VictoryRoadGateBadgeCheckScript
 
 	def_bg_events
 

--- a/maps/VioletCity.asm
+++ b/maps/VioletCity.asm
@@ -12,9 +12,9 @@ VioletCity_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .FlyPoint
+	callback MAPCALLBACK_NEWMAP, VioletCityFlypointCallback
 
-.FlyPoint:
+VioletCityFlypointCallback:
 	setflag ENGINE_FLYPOINT_VIOLET
 	endcallback
 

--- a/maps/ViridianCity.asm
+++ b/maps/ViridianCity.asm
@@ -8,9 +8,9 @@ ViridianCity_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_NEWMAP, .FlyPoint
+	callback MAPCALLBACK_NEWMAP, ViridianCityFlypointCallback
 
-.FlyPoint:
+ViridianCityFlypointCallback:
 	setflag ENGINE_FLYPOINT_VIRIDIAN
 	endcallback
 

--- a/maps/WhirlIslandLugiaChamber.asm
+++ b/maps/WhirlIslandLugiaChamber.asm
@@ -5,9 +5,9 @@ WhirlIslandLugiaChamber_MapScripts:
 	def_scene_scripts
 
 	def_callbacks
-	callback MAPCALLBACK_OBJECTS, .Lugia
+	callback MAPCALLBACK_OBJECTS, WhirlIslandLugiaChamberLugiaCallback
 
-.Lugia:
+WhirlIslandLugiaChamberLugiaCallback:
 	checkevent EVENT_FOUGHT_LUGIA
 	iftrue .NoAppear
 	checkitem SILVER_WING

--- a/maps/WillsRoom.asm
+++ b/maps/WillsRoom.asm
@@ -3,20 +3,20 @@
 
 WillsRoom_MapScripts:
 	def_scene_scripts
-	scene_script .LockDoor,   SCENE_WILLSROOM_LOCK_DOOR
-	scene_script .DummyScene, SCENE_WILLSROOM_NOOP
+	scene_script WillsRoomLockDoorScene, SCENE_WILLSROOM_LOCK_DOOR
+	scene_script WillsRoomNoopScene,     SCENE_WILLSROOM_NOOP
 
 	def_callbacks
-	callback MAPCALLBACK_TILES, .WillsRoomDoors
+	callback MAPCALLBACK_TILES, WillsRoomDoorsCallback
 
-.LockDoor:
-	sdefer .WillsDoorLocksBehindYou
+WillsRoomLockDoorScene:
+	sdefer WillsRoomDoorLocksBehindYouScript
 	end
 
-.DummyScene:
+WillsRoomNoopScene:
 	end
 
-.WillsRoomDoors:
+WillsRoomDoorsCallback:
 	checkevent EVENT_WILLS_ROOM_ENTRANCE_CLOSED
 	iffalse .KeepEntranceOpen
 	changeblock 4, 14, $2a ; wall
@@ -27,7 +27,7 @@ WillsRoom_MapScripts:
 .KeepExitClosed:
 	endcallback
 
-.WillsDoorLocksBehindYou:
+WillsRoomDoorLocksBehindYouScript:
 	applymovement PLAYER, WillsRoom_EnterMovement
 	refreshscreen $85
 	playsound SFX_STRENGTH


### PR DESCRIPTION
Co-Authored-By: Rangi <35663410+Rangi42@users.noreply.github.com>

Same as https://github.com/pret/pokecrystal/pull/981

Below is a list of merge conflicts I resolved if you'd like to review (discounting the files that don't exist in pokegold)
```
        both modified:   constants/event_flags.asm
        both modified:   engine/events/std_scripts.asm
        both modified:   maps/AzaleaTown.asm
        both modified:   maps/BurnedTower1F.asm
        both modified:   maps/BurnedTowerB1F.asm
        both modified:   maps/CeladonDeptStore6F.asm
        both modified:   maps/CianwoodCity.asm
        both modified:   maps/Colosseum.asm
        both modified:   maps/CopycatsHouse2F.asm
        both modified:   maps/DragonsDenB1F.asm
        both modified:   maps/EcruteakGym.asm
        both modified:   maps/EcruteakTinTowerEntrance.asm
        both modified:   maps/ElmsLab.asm
        both modified:   maps/GoldenrodCity.asm
        both modified:   maps/GoldenrodGameCorner.asm
        both modified:   maps/IlexForest.asm
        both modified:   maps/PlayersHouse1F.asm
        both modified:   maps/Pokecenter2F.asm
        both modified:   maps/Route34IlexForestGate.asm
        both modified:   maps/Route36.asm
        both modified:   maps/Route40.asm
        both modified:   maps/Route42.asm
        both modified:   maps/RuinsOfAlphAerodactylChamber.asm
        both modified:   maps/RuinsOfAlphHoOhChamber.asm
        both modified:   maps/RuinsOfAlphKabutoChamber.asm
        both modified:   maps/RuinsOfAlphOmanyteChamber.asm
        both modified:   maps/TinTower1F.asm
```