### PR TITLE
Identify `CHANNEL_FIELD16` as part of the note duration

### DIFF
--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -2205,8 +2205,8 @@ SetNoteDuration:
 	ld e, [hl]
 	inc hl
 	ld d, [hl]
-	; add ??? to the next result
-	ld hl, CHANNEL_FIELD16
+	; add hi duration to the next result
+	ld hl, CHANNEL_NOTE_DURATION + 1
 	add hl, bc
 	ld l, [hl]
 	; multiply Tempo by last result (NoteLength * LOW(delay))
@@ -2214,11 +2214,10 @@ SetNoteDuration:
 	; copy result to de
 	ld e, l
 	ld d, h
-	; store result in ???
-	ld hl, CHANNEL_FIELD16
+	; store result in NoteDuration
+	ld hl, CHANNEL_NOTE_DURATION + 1
 	add hl, bc
 	ld [hl], e
-	; store result in NoteDuration
 	ld hl, CHANNEL_NOTE_DURATION
 	add hl, bc
 	ld [hl], d
@@ -2283,9 +2282,9 @@ Tempo:
 	ld [hl], e
 	inc hl
 	ld [hl], d
-	; clear ???
+	; clear hi duration
 	xor a
-	ld hl, CHANNEL_FIELD16
+	ld hl, CHANNEL_NOTE_DURATION + 1
 	add hl, bc
 	ld [hl], a
 	ret

--- a/constants/audio_constants.asm
+++ b/constants/audio_constants.asm
@@ -48,8 +48,7 @@ DEF CHANNEL_FREQUENCY                   rw
 DEF CHANNEL_PITCH                       rb
 DEF CHANNEL_OCTAVE                      rb
 DEF CHANNEL_TRANSPOSITION               rb
-DEF CHANNEL_NOTE_DURATION               rb
-DEF CHANNEL_FIELD16                     rb
+DEF CHANNEL_NOTE_DURATION               rw
                                         rb_skip
 DEF CHANNEL_LOOP_COUNT                  rb
 DEF CHANNEL_TEMPO                       rw

--- a/macros/ram.asm
+++ b/macros/ram.asm
@@ -152,8 +152,7 @@ MACRO channel_struct
 \1Pitch::             db ; 0:rest 1-c:note
 \1Octave::            db ; 7-0 (0 is highest)
 \1Transposition::     db ; raises existing octaves (to repeat phrases)
-\1NoteDuration::      db ; frames remaining for the current note
-\1Field16::           ds 1
+\1NoteDuration::      dw ; frames remaining for the current note
                       ds 1
 \1LoopCount::         db
 \1Tempo::             dw


### PR DESCRIPTION
I'm not sure if this is really conceptually a two-byte value, or if this field16 byte has some less direct kind of influence on the note duration, but they're definitely related.