### PR TITLE
Inline NoSwarmWildmon label

### DIFF
--- a/engine/overworld/wildmons.asm
+++ b/engine/overworld/wildmons.asm
@@ -432,16 +432,16 @@ _SwarmWildmonCheck:
 	call CopyCurrMapDE
 	ld a, [wSwarmMapGroup]
 	cp d
-	jr nz, _NoSwarmWildmon
+	jr nz, .noSwarm
 	ld a, [wSwarmMapNumber]
 	cp e
-	jr nz, _NoSwarmWildmon
+	jr nz, .noSwarm
 	call LookUpWildmonsForMapDE
-	jr nc, _NoSwarmWildmon
+	jr nc, .noSwarm
 	scf
 	ret
 
-_NoSwarmWildmon:
+.noSwarm:
 	and a
 	ret
 


### PR DESCRIPTION
`_NoSwarmWildmon` is only used within the function `_SwarmWildmonCheck`, so this can be an inline label instead.