### PR TITLE
Use separate constants for wChosenCableClubRoom

### DIFF
--- a/constants/serial_constants.asm
+++ b/constants/serial_constants.asm
@@ -5,6 +5,12 @@
 	const LINK_TRADECENTER ; 2
 	const LINK_COLOSSEUM   ; 3
 
+; wChosenCableClubRoom
+	const_def
+	const CABLECLUBROOM_NULL        ; 0
+	const CABLECLUBROOM_TRADECENTER ; 1
+	const CABLECLUBROOM_COLOSSEUM   ; 2
+
 ; hSerialReceive high nybbles
 DEF SERIAL_TIMECAPSULE EQU $60
 DEF SERIAL_TRADECENTER EQU $70

--- a/engine/link/link.asm
+++ b/engine/link/link.asm
@@ -2124,13 +2124,13 @@ WaitForOtherPlayerToExit:
 	ret
 
 SetBitsForLinkTradeRequest:
-	ld a, LINK_TRADECENTER - 1
+	ld a, CABLECLUBROOM_TRADECENTER
 	ld [wPlayerLinkAction], a
 	ld [wChosenCableClubRoom], a
 	ret
 
 SetBitsForBattleRequest:
-	ld a, LINK_COLOSSEUM - 1
+	ld a, CABLECLUBROOM_COLOSSEUM
 	ld [wPlayerLinkAction], a
 	ld [wChosenCableClubRoom], a
 	ret
@@ -2144,7 +2144,7 @@ SetBitsForTimeCapsuleRequest:
 	ldh [rSC], a
 	ld a, SC_START | SC_EXTERNAL
 	ldh [rSC], a
-	xor a ; LINK_NULL
+	xor a ; CABLECLUBROOM_NULL
 	ld [wPlayerLinkAction], a
 	ld [wChosenCableClubRoom], a
 	ret


### PR DESCRIPTION
These numbers aren't related to the LINK_ values at all, it's just a
coincidence.

Changing these is an easy way for games to force incompatibility with
the original game.
