### PR TITLE
Fix some issues with C tools, and build them with `-std=c17`

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all clean
 
 CC := gcc
-CFLAGS := -O3 -std=c11 -Wall -Wextra -pedantic
+CFLAGS := -O3 -std=c17 -Wall -Wextra -pedantic
 
 tools := \
 	gbcpal \

--- a/tools/gfx.c
+++ b/tools/gfx.c
@@ -67,6 +67,9 @@ void parse_args(int argc, char *argv[]) {
 			break;
 		case 'd':
 			options.depth = strtoul(optarg, NULL, 0);
+			if (options.depth != 1 && options.depth != 2) {
+				error_exit("bit depth must be 1 or 2, not %d\n", options.depth);
+			}
 			break;
 		case 'p':
 			options.png_file = optarg;

--- a/tools/make_patch.c
+++ b/tools/make_patch.c
@@ -228,7 +228,8 @@ void interpret_command(char *command, const struct Symbol *current_hook, const s
 	}
 
 	// Get the arguments
-	char *argv[argc]; // VLA
+	char *argv[argc + 1]; // VLA (cannot be zero-length)
+	argv[argc] = NULL;
 	char *arg = command;
 	for (int i = 0; i < argc; i++) {
 		while (*arg && !isspace((unsigned)*arg)) {
@@ -515,7 +516,7 @@ int main(int argc, char *argv[]) {
 	FILE *new_rom = xfopen(argv[1], 'r');
 	FILE *orig_rom = xfopen(argv[2], 'r');
 	if (new_rom == stdin || orig_rom == stdin) {
-		error_exit("Error: Cannot read ROM file from stdin (not rewindable)");
+		error_exit("Error: Cannot read ROM file from stdin (not rewindable)\n");
 	}
 	struct Buffer *patches = process_template(argv[3], argv[4], new_rom, orig_rom, symbols, ignore_addr, ignore_size);
 

--- a/tools/stadium.c
+++ b/tools/stadium.c
@@ -89,5 +89,6 @@ int main(int argc, char *argv[]) {
 		calculate_checksums(file);
 	}
 	write_u8(filename, file, filesize);
+	free(file);
 	return 0;
 }


### PR DESCRIPTION
Debugged with:
```make
CFLAGS := -O3 -std=c17 -Wall -Wextra -pedantic \
          -Wno-unknown-warning-option \
          -Wcast-align -Wcast-qual -Wduplicated-branches -Wduplicated-cond \
          -Wfloat-equal -Wlogical-op -Wnull-dereference -Wshift-overflow=2 \
          -Wstringop-overflow=4 -Wtrampolines -Wundef -Wuninitialized -Wunused -Wshadow \
          -Wformat=2 -Wformat-overflow=2 -Wformat-truncation=1 -Wno-format-nonliteral \
          -ggdb3 -Og -fno-omit-frame-pointer -fno-optimize-sibling-calls \
          -D_GLIBCXX_ASSERTIONS -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG \
          -fsanitize=address -fsanitize=undefined -fsanitize=float-divide-by-zero
```